### PR TITLE
Added support for post version 3.0 which doesn't come with name info.

### DIFF
--- a/src/encoding.js
+++ b/src/encoding.js
@@ -188,15 +188,26 @@ function GlyphNames(post) {
             this.names[i] = exports.standardNames[i + post.glyphNameIndex[i]];
         }
         break;
+    case 3.0:
+        this.names = null;
+        break;
     }
 }
 
 GlyphNames.prototype.nameToGlyphIndex = function (name) {
-    return this.names.indexOf(name);
+    if (this.names) {
+        return this.names.indexOf(name);
+    } else {
+        return null;
+    }
 };
 
 GlyphNames.prototype.glyphIndexToName = function (gid) {
-    return this.names[gid];
+    if (this.names) {
+        return this.names[gid];
+    } else {
+        return null;
+    }
 };
 
 function addGlyphNames(font) {


### PR DESCRIPTION
I‘m not 100% sure if I made it correctly. I was working on some fonts with postscript table version 3.0, which opentype.js doesn't support. So I added another branch in the version switch. And [the spec says](https://www.microsoft.com/typography/OTSPEC/post.htm) it might not come with a names table.

