### PR TITLE
Add CFF Type 2 CharString operator 'flex1'

### DIFF
--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -425,6 +425,38 @@ function parseCFFCharstring(code, font, index) {
             case 12: // escape
                 v = code[i];
                 i += 1;
+		switch (v) {
+		// 4.1 Path Construction Operators
+		// |- dx1 dy1 dx2 dy2 dx3 dy3 dx4 dy4 dx5 dy5 d6         |-
+		case   37:  // 12 37  0c 25  flex1
+		    var jpx, jpy, c3x, c3y, c4x, c4y;
+
+		    c1x = x   + stack.shift();    // dx1
+		    c1y = y   + stack.shift();    // dy1
+		    c2x = c1x + stack.shift();    // dx2
+		    c2y = c1y + stack.shift();    // dy2
+		    jpx = c2x + stack.shift();    // dx3
+		    jpy = c2y + stack.shift();    // dy3
+		    c3x = jpx + stack.shift();    // dx4
+		    c3y = jpy + stack.shift();    // dy4
+		    c4x = c3x + stack.shift();    // dx5
+		    c4y = c3y + stack.shift();    // dy5
+
+		    if ( Math.abs(c4x - x) > Math.abs(c4y - y) ) {
+		      x   = c4x + stack.shift();
+		    } else {
+		      y   = c4y + stack.shift();
+		    }
+
+		    p.curveTo(c1x, c1y, c2x, c2y, jpx, jpy);
+		    p.curveTo(c3x, c3y, c4x, c4y, x, y);
+                    //p.lineTo(x, y);
+		    break;
+
+		default:
+		    console.log('saw unsupported operator %d', 1200+v);
+		    stack.length = 0;
+		}
                 break;
             case 14: // endchar
                 if (stack.length > 0 && !haveWidth) {
@@ -796,7 +828,7 @@ function glyphToOps(glyph) {
                 y1: _13 * y + _23 * cmd.y1,
                 x2: _13 * cmd.x + _23 * cmd.x1,
                 y2: _13 * cmd.y + _23 * cmd.y1
-            }
+            };
         }
 
         if (cmd.type === 'M') {


### PR DESCRIPTION
Issue #85 reported malformed characters displayed from two OTF font files.
Investigation found that the CFF CharString instructions in these fonts
employed the rather unusual operator 'flex1', which was not implemented
by opentype.js.  About 8 out of 300+ characters used the operator.

Upon encountering the 'flex1' operator the code would simply skip over
the operator.  This resulted in the accumulated operand values being
left on the stack, which disrupted execution of following operators, and
left the affected characters obviously distorted.  Clearing of the stack
when an unsupported operator is found was added to fix that.

This still left the characters distorted because one of the drawing
instructions was missing.  (In this case the missing part was vertical
so the resulting curves were not tall enough).

Rereading the Adobe documentation induced dread but finally resulted in
working code to implement this operator, though not completely.  When fully
implemented code is supposed to decide whether the Bézier curves will
actually be so shallow that they should just be replaced with a straight
line.  This fix instead always outputs the two Bézier curves.

Tested against the two fonts referenced in issue #85.  (Thank you @georg-paul)
The glyphs 'D' (GID#18) and 'P' (GID#79) were example problems that were
corrected when using font LeagueGothic-Regular.otf    Glyph 't' (GID#294)
was the example problem in font Neris-Light.otf and it was also corrected
with these fixes.

Note that JSHint pointed out the lack of a semicolon from a prior fix #86
and this was added to this fix.

This PR fixes #85 