### PR TITLE
Add console.log stack dumping

### DIFF
--- a/font-inspector.html
+++ b/font-inspector.html
@@ -142,6 +142,8 @@ function onReadFile(e) {
             showErrorMessage('');
         } catch (err) {
             showErrorMessage(err.toString());
+            if (err.stack) console.log(err.stack);
+	    throw(err);
         }
     }
     reader.onerror = function (err) {

--- a/glyph-inspector.html
+++ b/glyph-inspector.html
@@ -377,6 +377,7 @@ function onReadFile(e) {
             onFontLoaded(font);
         } catch (err) {
             showErrorMessage(err.toString());
+            if (err.stack) console.log(err.stack);
             throw(err);
         }
     }


### PR DESCRIPTION
While debugging it is very useful to have all possible information in
the rare (cough!) event of an exception.  While both the font-inspector
and the glyph-inspector were notifying the user of exceptions via the
web page, the additional information useful to developers was not seen.

This change adds logging of an exception's stack information to these
two web pages.  Previously little or nothing would be seen in a browser's
debug console window:

(font-inspector)
```
           A CID Font!
```

(glyph-inspector)

```
         A CID Font!
  Uncaught ReferenceError: xxfont is not defined  glyph-inspector.html:381
```

This change adds logging of the exception along with stack information:
```
           A CID Font!
  ReferenceError: xxfont is not defined           glyph-inspector.html:380
      at Object.parseCFFTable [as parse] (opentype.js:2271)
      at Object.parseBuffer [as parse] (opentype.js:916)
      at FileReader.reader.onload (glyph-inspector.html:375)
  Uncaught ReferenceError: xxfont is not defined  glyph-inspector.html:381
```