### PR TITLE
Adding support for Path2D based drawing

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -149,6 +149,24 @@ Font.prototype.getPath = function (text, x, y, fontSize, options) {
     return fullPath;
 };
 
+// Create a Path2D object that represents the given text.
+//
+// text - The text to create.
+// x - Horizontal position of the beginning of the text. (default: 0)
+// y - Vertical position of the *baseline* of the text. (default: 0)
+// fontSize - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`. (default: 72)
+// Options is an optional object that contains:
+// - kerning - Whether to take kerning information into account. (default: true)
+//
+// Returns a Path object.
+Font.prototype.getPath2D = function (text, x, y, fontSize, options) {
+    var fullPath = new Path2D();
+    this.forEachGlyph(text, x, y, fontSize, options, function (glyph, x, y, fontSize) {
+        glyph.appendToPath2D(fullPath, x, y, fontSize);
+    });
+    return fullPath;
+};
+
 // Draw the text on the given drawing context.
 //
 // ctx - A 2D drawing context, like Canvas.
@@ -158,8 +176,11 @@ Font.prototype.getPath = function (text, x, y, fontSize, options) {
 // fontSize - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`. (default: 72)
 // Options is an optional object that contains:
 // - kerning - Whether to take kerning information into account. (default: true)
+// - fillStyle - The fill color you would like to apply
 Font.prototype.draw = function (ctx, text, x, y, fontSize, options) {
-    this.getPath(text, x, y, fontSize, options).draw(ctx);
+    var path = this.getPath2D(text, x, y, fontSize, options);
+    ctx.fillStyle = options.fillStyle || "black";
+    ctx.fill(path);
 };
 
 // Draw the points of all glyphs in the text.

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -65,6 +65,38 @@ Glyph.prototype.getPath = function (x, y, fontSize) {
     return p;
 };
 
+// Append the glyph's to a Path to a Path2D object for drawing.
+//
+// p - The Path2D object you would like to append
+// x - Horizontal position of the glyph. (default: 0)
+// y - Vertical position of the *baseline* of the glyph. (default: 0)
+// fontSize - Font size, in pixels (default: 72).
+Glyph.prototype.appendToPath2D = function (p, x, y, fontSize) {
+    var scale, commands, cmd;
+    x = x !== undefined ? x : 0;
+    y = y !== undefined ? y : 0;
+    fontSize = fontSize !== undefined ? fontSize : 72;
+    scale = 1 / this.font.unitsPerEm * fontSize;
+    commands = this.path.commands;
+    for (var i = 0; i < commands.length; i += 1) {
+        cmd = commands[i];
+        if (cmd.type === 'M') {
+            p.moveTo(x + (cmd.x * scale), y + (-cmd.y * scale));
+        } else if (cmd.type === 'L') {
+            p.lineTo(x + (cmd.x * scale), y + (-cmd.y * scale));
+        } else if (cmd.type === 'Q') {
+            p.quadraticCurveTo(x + (cmd.x1 * scale), y + (-cmd.y1 * scale),
+                               x + (cmd.x * scale), y + (-cmd.y * scale));
+        } else if (cmd.type === 'C') {
+            p.curveTo(x + (cmd.x1 * scale), y + (-cmd.y1 * scale),
+                      x + (cmd.x2 * scale), y + (-cmd.y2 * scale),
+                      x + (cmd.x * scale), y + (-cmd.y * scale));
+        } else if (cmd.type === 'Z') {
+            p.closePath();
+        }
+    }
+};
+
 // Split the glyph into contours.
 // This function is here for backwards compatibility, and to
 // provide raw access to the TrueType glyph outlines.


### PR DESCRIPTION
This branch implements drawing based on Path2D objects.
https://developer.mozilla.org/en-US/docs/Web/API/Path2D.Path2D

This is a new feature in latest Chrome and Firefox, there is a polyfill for browsers that don't support it yet.
https://github.com/google/canvas-5-polyfill

Because drawing should happen all at once drawing should be faster.
