### PR TITLE
Use SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
     "ttf",
     "type"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/nodebox/opentype.js/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/nodebox/opentype.js.git"


### PR DESCRIPTION
Before this change, npm install would give the following warning:

    $ npm install
    npm WARN package.json opentype.js@0.4.8 No license field.

According to https://docs.npmjs.com/files/package.json#license
"licenses" has been deprecated by "license".