### PR TITLE
Support ‘fvar’ tables for variable fonts

### DIFF
--- a/font-inspector.html
+++ b/font-inspector.html
@@ -49,6 +49,8 @@
         <dl id="post-table"></dl>
         <h3 class="collapsed">Character To Glyph Index Mapping Table <a href="https://www.microsoft.com/typography/OTSPEC/cmap.htm" target="_blank">cmap</a></h3>
         <dl id="cmap-table"></dl>
+        <h3 class="collapsed">Font Variations table <a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html" target="_blank">fvar</a></h3>
+        <dl id="fvar-table"></dl>
     </div>
 
     <hr>

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -15,6 +15,7 @@ var path = require('./path');
 
 var cmap = require('./tables/cmap');
 var cff = require('./tables/cff');
+var fvar = require('./tables/fvar');
 var glyf = require('./tables/glyf');
 var gpos = require('./tables/gpos');
 var head = require('./tables/head');
@@ -109,6 +110,9 @@ function parseBuffer(buffer) {
         case 'cmap':
             font.tables.cmap = cmap.parse(data, offset);
             font.encoding = new encoding.CmapEncoding(font.tables.cmap);
+            break;
+        case 'fvar':
+            font.tables.fvar = fvar.parse(data, offset);
             break;
         case 'head':
             font.tables.head = head.parse(data, offset);

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -8,11 +8,13 @@
 // should replace 'nameID' by 'name', and keep it as dictionary like
 // {en: 'Bold', fr: 'Gras'}? Decoding OpenType/TrueType name IDs to
 // IETF BCP-47 language tags would be certainly doable, but it will
-// probably need large changes to the 'name' handling of opentype.js.
+// need large changes to the 'name' handling of opentype.js.
 // Until this is resolved, we can't write back 'fvar' tables when
 // writing fonts (if we did, our name IDs would be dangling
 // references).  Therefore, the make() function is currently only
 // called from test code.
+//
+// See also https://github.com/nodebox/opentype.js/issues/144.
 
 'use strict';
 

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -1,0 +1,135 @@
+// The `fvar` table stores font variation axes and instances.
+// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html
+
+// FIXME: Currently, we drop the names of design axes ("Weight") and
+// font instances ("Thin Condensed"). In the spec and also in real
+// fonts, these are multilingual properties: The font supplies the
+// same name in French, English, etc. In the code below, perhaps we
+// should replace 'nameID' by 'name', and keep it as dictionary like
+// {en: 'Bold', fr: 'Gras'}? Decoding OpenType/TrueType name IDs to
+// IETF BCP-47 language tags would be certainly doable, but it will
+// probably need large changes to the 'name' handling of opentype.js.
+// Until this is resolved, we can't write back 'fvar' tables when
+// writing fonts (if we did, our name IDs would be dangling
+// references).  Therefore, the make() function is currently only
+// called from test code.
+
+'use strict';
+
+var check = require('../check');
+var parse = require('../parse');
+var table = require('../table');
+
+function makeFvarAxis(axis) {
+    return new table.Table('fvarAxis', [
+        {name: 'tag', type: 'TAG', value: axis.tag},
+        {name: 'minValue', type: 'FIXED', value: axis.minValue << 16},
+        {name: 'defaultValue', type: 'FIXED', value: axis.defaultValue << 16},
+        {name: 'maxValue', type: 'FIXED', value: axis.maxValue << 16},
+        {name: 'flags', type: 'USHORT', value: axis.flags},
+        {name: 'nameID', type: 'USHORT', value: axis.nameID}
+    ]);
+}
+
+function parseFvarAxis(data, start) {
+    var axis = {};
+    var p = new parse.Parser(data, start);
+    axis.tag = p.parseTag();
+    axis.minValue = p.parseFixed();
+    axis.defaultValue = p.parseFixed();
+    axis.maxValue = p.parseFixed();
+    axis.flags = p.parseUShort();
+    axis.nameID = p.parseUShort();
+    return axis;
+}
+
+function makeFvarInstance(inst, axes) {
+    var fields = [
+        {name: 'nameID', type: 'USHORT', value: inst.nameID},
+        {name: 'flags', type: 'USHORT', value: inst.flags}
+    ];
+
+    for (var i = 0; i < axes.length; ++i) {
+        var axisTag = axes[i].tag;
+        fields.push({
+            name: 'axis ' + axisTag,
+            type: 'FIXED',
+            value: inst.coordinates[axisTag] << 16
+        });
+    }
+
+    return new table.Table('fvarInstance', fields);
+}
+
+function parseFvarInstance(data, start, axes) {
+    var inst = {};
+    var p = new parse.Parser(data, start);
+    inst.nameID = p.parseUShort();
+    inst.flags = p.parseUShort();
+
+    inst.coordinates = {};
+    for (var i = 0; i < axes.length; ++i) {
+        inst.coordinates[axes[i].tag] = p.parseFixed();
+    }
+
+    return inst;
+}
+
+function makeFvarTable(fvar) {
+    var result = new table.Table('fvar', [
+        {name: 'version', type: 'ULONG', value: 0x10000},
+        {name: 'offsetToData', type: 'USHORT', value: 0},
+        {name: 'countSizePairs', type: 'USHORT', value: 2},
+        {name: 'axisCount', type: 'USHORT', value: fvar.axes.length},
+        {name: 'axisSize', type: 'USHORT', value: 20},
+        {name: 'instanceCount', type: 'USHORT', value: fvar.instances.length},
+        {name: 'instanceSize', type: 'USHORT', value: 4 + fvar.axes.length * 4}
+    ]);
+    result.offsetToData = result.sizeOf();
+
+    for (var i = 0; i < fvar.axes.length; i++) {
+        result.fields.push({
+            name: 'axis ' + i,
+            type: 'TABLE',
+            value: makeFvarAxis(fvar.axes[i])});
+    }
+
+    for (var j = 0; j < fvar.instances.length; j++) {
+        result.fields.push({
+            name: 'instance ' + j,
+            type: 'TABLE',
+            value: makeFvarInstance(fvar.instances[j], fvar.axes)
+        });
+    }
+
+    return result;
+}
+
+function parseFvarTable(data, start) {
+    var p = new parse.Parser(data, start);
+    var tableVersion = p.parseULong();
+    check.argument(tableVersion === 0x00010000, 'Unsupported fvar table version.');
+    var offsetToData = p.parseOffset16();
+    // Skip countSizePairs.
+    p.skip('uShort', 1);
+    var axisCount = p.parseUShort();
+    var axisSize = p.parseUShort();
+    var instanceCount = p.parseUShort();
+    var instanceSize = p.parseUShort();
+
+    var axes = [];
+    for (var i = 0; i < axisCount; i++) {
+        axes.push(parseFvarAxis(data, start + offsetToData + i * axisSize));
+    }
+
+    var instances = [];
+    var instanceStart = start + offsetToData + axisCount * axisSize;
+    for (var j = 0; j < instanceCount; j++) {
+        instances.push(parseFvarInstance(data, instanceStart + j * instanceSize, axes));
+    }
+
+    return {axes:axes, instances:instances};
+}
+
+exports.make = makeFvarTable;
+exports.parse = parseFvarTable;

--- a/test/tables/fvar.js
+++ b/test/tables/fvar.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var assert = require('assert');
+var mocha = require('mocha');
+var describe = mocha.describe;
+var it = mocha.it;
+var testutil = require('../testutil.js');
+var fvar = require('../../src/tables/fvar.js');
+
+describe('tables/fvar.js', function() {
+    var data =
+        '00 01 00 00 00 10 00 02 00 02 00 14 00 02 00 0C ' +
+        '77 67 68 74 00 64 00 00 01 90 00 00 03 84 00 00 00 00 01 01 ' +
+        '77 64 74 68 00 32 00 00 00 64 00 00 00 C8 00 00 00 00 01 02 ' +
+        '01 03 00 00 01 2C 00 00 00 64 00 00 ' +
+        '01 04 00 00 01 2C 00 00 00 4B 00 00';
+
+    var table = {
+        axes: [
+            {
+                tag: 'wght',
+                minValue: 100,
+                defaultValue: 400,
+                maxValue: 900,
+                flags: 0,
+                nameID: 257
+            },
+            {
+                tag: 'wdth',
+                minValue: 50,
+                defaultValue: 100,
+                maxValue: 200,
+                flags: 0,
+                nameID: 258
+            }
+        ],
+        instances: [
+            {
+                nameID: 259,
+                flags: 0,
+                coordinates: {wght: 300, wdth: 100}
+            },
+            {
+                nameID: 260,
+                flags: 0,
+                coordinates: {wght: 300, wdth: 75}
+            }
+        ]
+    };
+
+    it('can parse a font variations table', function() {
+        assert.deepEqual(table, fvar.parse(testutil.unhex(data), 0));
+    });
+
+    it('can make a font variations table', function() {
+        assert.deepEqual(data, testutil.hex(fvar.make(table).encode()));
+    });
+});

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -1,5 +1,19 @@
 'use strict';
 
+var hex = function(bytes) {
+    var values = [];
+    for (var i = 0; i < bytes.length; ++i) {
+        var b = bytes[i];
+        if (b < 16) {
+            values.push('0' + b.toString(16).toUpperCase());
+        } else {
+            values.push(b.toString(16).toUpperCase());
+        }
+    }
+
+    return values.join(' ');
+};
+
 var unhex = function(str) {
     str = str.split(' ').join('');
     var len = str.length / 2;
@@ -11,4 +25,5 @@ var unhex = function(str) {
     return data;
 };
 
+exports.hex = hex;
 exports.unhex = unhex;

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -2,16 +2,16 @@
 
 var hex = function(bytes) {
     var values = [];
-    for (var i = 0; i < bytes.length; ++i) {
+    for (var i = 0; i < bytes.length; i++) {
         var b = bytes[i];
         if (b < 16) {
-            values.push('0' + b.toString(16).toUpperCase());
+            values.push('0' + b.toString(16));
         } else {
-            values.push(b.toString(16).toUpperCase());
+            values.push(b.toString(16));
         }
     }
 
-    return values.join(' ');
+    return values.join(' ').toUpperCase();
 };
 
 var unhex = function(str) {


### PR DESCRIPTION
This table is part of Apple’s Advanced Typography, not OpenType; so
this might be considered out of scope for the opentype.js project.
On the other hand, the FreeType project has implemented AAT variation
axes, so the utility goes beyond MacOS. If opentype.js was fine with
accepting changes for AAT tables, I would implement the ‘avar’ and
‘gvar’ tables in subsequent changes.