### PR TITLE
Parse ‘ltag’ table, and pipe it through to name.parse()

### DIFF
--- a/src/tables/ltag.js
+++ b/src/tables/ltag.js
@@ -1,0 +1,61 @@
+// The `ltag` table stores IETF BCP-47 language tags. It allows supporting
+// languages for which TrueType does not assign a numeric code.
+// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6ltag.html
+// http://www.w3.org/International/articles/language-tags/
+// http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+
+'use strict';
+
+var check = require('../check');
+var parse = require('../parse');
+var table = require('../table');
+
+function makeLtagTable(tags) {
+    var result = new table.Table('ltag', [
+        {name: 'version', type: 'ULONG', value: 1},
+        {name: 'flags', type: 'ULONG', value: 0},
+        {name: 'numTags', type: 'ULONG', value: tags.length}
+    ]);
+
+    var stringPool = '';
+    var stringPoolOffset = 12 + tags.length * 4;
+    for (var i = 0; i < tags.length; ++i) {
+        var pos = stringPool.indexOf(tags[i]);
+        if (pos < 0) {
+            pos = stringPool.length;
+            stringPool += tags[i];
+        }
+
+        result.fields.push({name: 'offset ' + i, type: 'USHORT', value: stringPoolOffset + pos});
+        result.fields.push({name: 'length ' + i, type: 'USHORT', value: tags[i].length});
+    }
+
+    result.fields.push({name: 'stringPool', type: 'CHARARRAY', value: stringPool});
+    return result;
+}
+
+function parseLtagTable(data, start) {
+    var p = new parse.Parser(data, start);
+    var tableVersion = p.parseULong();
+    check.argument(tableVersion === 1, 'Unsupported ltag table version.');
+    // The 'ltag' specification does not define any flags; skip the field.
+    p.skip('uLong', 1);
+    var numTags = p.parseULong();
+
+    var tags = [];
+    for (var i = 0; i < numTags; i++) {
+        var tag = '';
+        var offset = start + p.parseUShort();
+        var length = p.parseUShort();
+        for (var j = offset; j < offset + length; ++j) {
+            tag += String.fromCharCode(data.getInt8(j));
+        }
+
+        tags.push(tag);
+    }
+
+    return tags;
+}
+
+exports.make = makeLtagTable;
+exports.parse = parseLtagTable;

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -34,10 +34,14 @@ var nameTableNames = [
     'wwsSubfamily'            // 22
 ];
 
-// Parse the naming `name` table
+// Parse the naming `name` table.
 // Only Windows Unicode English names are supported.
-// Format 1 additional fields are not supported
-function parseNameTable(data, start) {
+// Format 1 additional fields are not supported.
+// ltag is the content of the `ltag' table, such as ['en', 'zh-Hans', 'de-CH-1904'];
+// currently this is not yet used, it is merely piped through to this function.
+// FIXME: If the font supplies an `ltag' table, use it.
+function parseNameTable(data, start, ltag) {
+    if (ltag);  // Suppress warning for 'ltag' not being used yet.
     var name = {};
     var p = new parse.Parser(data, start);
     name.format = p.parseUShort();

--- a/test/tables/ltag.js
+++ b/test/tables/ltag.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var assert = require('assert');
+var mocha = require('mocha');
+var describe = mocha.describe;
+var it = mocha.it;
+var testutil = require('../testutil.js');
+var ltag = require('../../src/tables/ltag.js');
+
+describe('tables/ltag.js', function() {
+    var data =
+        '00 00 00 01 00 00 00 00 00 00 00 04 00 1C 00 02 ' +
+        '00 1E 00 07 00 1E 00 02 00 25 00 13 65 6E 7A 68 ' +
+        '2D 48 61 6E 74 73 6C 2D 72 6F 7A 61 6A 2D 73 6F ' +
+        '6C 62 61 2D 31 39 39 34';
+    var tags = ['en', 'zh-Hant', 'zh', 'sl-rozaj-solba-1994'];
+
+    it('can make a language tag table', function() {
+        assert.deepEqual(data, testutil.hex(ltag.make(tags).encode()));
+    });
+
+    it('can parse a language tag table', function() {
+        assert.deepEqual(tags, ltag.parse(testutil.unhex('DE AD BE EF ' + data), 4));
+    });
+});


### PR DESCRIPTION
The ‘ltag’ table contains IETF BCP-47 language tags, so fonts can
support arbitrary languages. It is basically Apple’s version of what
Microsoft did in “format 1” naming tables of OpenType.

In a later change, I will modify the ‘name’ parser so it actually uses
these language tags (if people are fine with this plan). It should be
straightforward to support both the Apple and the Microsoft way.

See also https://github.com/nodebox/opentype.js/issues/144 for context.