### PR TITLE
Implement MACSTRING codec

### DIFF
--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -92,12 +92,56 @@ function makeNameRecord(platformID, encodingID, languageID, nameID, length, offs
     ]);
 }
 
+var macEncodings = (function() {
+    /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+
+    // encode.MACSTRING uses the encoding IDs as cache keys for a WeakMap.
+    // Therefore, they must be Objects. We use IANA character set IDs.
+    var croatian = new String('x-mac-croatian');
+    var cyrillic = new String('x-mac-cyrillic');
+    var greek = new String('x-mac-greek');
+    var icelandic = new String('x-mac-icelandic');
+    var centralEurope = new String('x-mac-ce');
+    var roman = new String('macintosh');
+    var romanian = new String('x-mac-romanian');
+    var turkish = new String('x-mac-turkish');
+
+    // https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6name.html
+    // https://github.com/behdad/fonttools/issues/236
+    return {
+        0: {
+            0: roman,
+            15: icelandic,
+            17: turkish,
+            18: croatian,
+            24: centralEurope,
+            25: centralEurope,
+            26: centralEurope,
+            27: centralEurope,
+            28: centralEurope,
+            36: centralEurope,
+            37: romanian,
+            38: centralEurope,
+            39: centralEurope,
+            40: centralEurope
+        },
+        6: greek,
+        7: cyrillic,
+        29: centralEurope,
+        35: turkish,
+        37: icelandic
+    };
+}());
+
 function addMacintoshNameRecord(t, recordID, s, offset) {
     // Macintosh, Roman, English
-    var stringBytes = encode.STRING(s);
-    t.records.push(makeNameRecord(1, 0, 0, recordID, stringBytes.length, offset));
-    t.strings.push(stringBytes);
-    offset += stringBytes.length;
+    var stringBytes = encode.MACSTRING(s, macEncodings[0][0]);
+    if (stringBytes !== undefined) {
+        t.records.push(makeNameRecord(1, 0, 0, recordID, stringBytes.length, offset));
+        t.strings.push(stringBytes);
+        offset += stringBytes.length;
+    }
+
     return offset;
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -238,6 +238,144 @@ sizeOf.UTF16 = function(v) {
     return v.length * 2;
 };
 
+// Data for converting old eight-bit Macintosh encodings to Unicode.
+// This representation is optimized for decoding; encoding is slower
+// and needs more memory. The assumption is that all opentype.js users
+// want to open fonts, but saving a font will be comperatively rare
+// so it can be more expensive. Keyed by IANA character set name.
+//
+// Python script for generating these strings:
+//
+//     s = u''.join([chr(c).decode('mac_greek') for c in range(128, 256)])
+//     print(s.encode('utf-8'))
+var eightBitMacEncodings = {
+    'x-mac-croatian':  // Python: 'mac_croatian'
+        'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®Š™´¨≠ŽØ∞±≤≥∆µ∂∑∏š∫ªºΩžø' +
+        '¿¡¬√ƒ≈Ć«Č… ÀÃÕŒœĐ—“”‘’÷◊©⁄€‹›Æ»–·‚„‰ÂćÁčÈÍÎÏÌÓÔđÒÚÛÙıˆ˜¯πË˚¸Êæˇ',
+    'x-mac-cyrillic':  // Python: 'mac_cyrillic'
+        'АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ†°Ґ£§•¶І®©™Ђђ≠Ѓѓ∞±≤≥іµґЈЄєЇїЉљЊњ' +
+        'јЅ¬√ƒ≈∆«»… ЋћЌќѕ–—“”‘’÷„ЎўЏџ№Ёёяабвгдежзийклмнопрстуфхцчшщъыьэю',
+    'x-mac-greek':  // Python: 'mac_greek'
+        'Ä¹²É³ÖÜ΅àâä΄¨çéèêë£™îï•½‰ôö¦€ùûü†ΓΔΘΛΞΠß®©ΣΪ§≠°·Α±≤≥¥ΒΕΖΗΙΚΜΦΫΨΩ' +
+        'άΝ¬ΟΡ≈Τ«»… ΥΧΆΈœ–―“”‘’÷ΉΊΌΎέήίόΏύαβψδεφγηιξκλμνοπώρστθωςχυζϊϋΐΰ\u00AD',
+    'x-mac-icelandic':  // Python: 'mac_iceland'
+        'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûüÝ°¢£§•¶ß®©™´¨≠ÆØ∞±≤≥¥µ∂∑∏π∫ªºΩæø' +
+        '¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸ⁄€ÐðÞþý·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙıˆ˜¯˘˙˚¸˝˛ˇ',
+    'x-mac-ce':  // Python: 'mac_latin2'
+        'ÄĀāÉĄÖÜáąČäčĆćéŹźĎíďĒēĖóėôöõúĚěü†°Ę£§•¶ß®©™ę¨≠ģĮįĪ≤≥īĶ∂∑łĻļĽľĹĺŅ' +
+        'ņŃ¬√ńŇ∆«»… ňŐÕőŌ–—“”‘’÷◊ōŔŕŘ‹›řŖŗŠ‚„šŚśÁŤťÍŽžŪÓÔūŮÚůŰűŲųÝýķŻŁżĢˇ',
+    macintosh:  // Python: 'mac_roman'
+        'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ÆØ∞±≤≥¥µ∂∑∏π∫ªºΩæø' +
+        '¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸ⁄€‹›ﬁﬂ‡·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙıˆ˜¯˘˙˚¸˝˛ˇ',
+    'x-mac-romanian':  // Python: 'mac_romanian'
+        'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ĂȘ∞±≤≥¥µ∂∑∏π∫ªºΩăș' +
+        '¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸ⁄€‹›Țț‡·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙıˆ˜¯˘˙˚¸˝˛ˇ',
+    'x-mac-turkish':  // Python: 'mac_turkish'
+        'ÄÅÇÉÑÖÜáàâäãåçéèêëíìîïñóòôöõúùûü†°¢£§•¶ß®©™´¨≠ÆØ∞±≤≥¥µ∂∑∏π∫ªºΩæø' +
+        '¿¡¬√ƒ≈∆«»… ÀÃÕŒœ–—“”‘’÷◊ÿŸĞğİıŞş‡·‚„‰ÂÊÁËÈÍÎÏÌÓÔÒÚÛÙˆ˜¯˘˙˚¸˝˛ˇ'
+};
+
+// Decodes an old-style Macintosh string. Returns either a Unicode JavaScript
+// string, or 'undefined' if the encoding is unsupported. For example, we do
+// not support Chinese, Japanese or Korean because these would need large
+// mapping tables.
+decode.MACSTRING = function(dataView, offset, dataLength, encoding) {
+    var table = eightBitMacEncodings[encoding];
+    if (table === undefined) {
+        return undefined;
+    }
+
+    var result = '';
+    for (var i = 0; i < dataLength; i++) {
+        var c = dataView.getUint8(offset + i);
+        // In all eight-bit Mac encodings, the characters 0x00..0x7F are
+        // mapped to U+0000..U+007F; we only need to look up the others.
+        if (c <= 0x7F) {
+            result += String.fromCharCode(c);
+        } else {
+            result += table[c & 0x7F];
+        }
+    }
+
+    return result;
+};
+
+// Helper function for encode.MACSTRING. Returns a dictionary for mapping
+// Unicode character codes to their 8-bit MacOS equivalent. This table
+// is not exactly a super cheap data structure, but we do not care because
+// encoding Macintosh strings is only rarely needed in typical applications.
+// Since we use encoding as a cache key for WeakMap, it must be a String
+// object and not a literal.
+var macEncodingTableCache = typeof WeakMap === 'function' && new WeakMap();
+var getMacEncodingTable = function(encoding) {
+    // We can't do "if (cache.has(key)) {return cache.get(key)}" here:
+    // since garbage collection may run at any time, it could also kick in
+    // between the calls to cache.has() and cache.get(). In that case,
+    // we would return 'undefined' even though we do support the encoding.
+    if (macEncodingTableCache) {
+        var cachedTable = macEncodingTableCache.get(encoding);
+        if (cachedTable !== undefined) {
+            return cachedTable;
+        }
+    }
+
+    var decodingTable = eightBitMacEncodings[encoding];
+    if (decodingTable === undefined) {
+        return undefined;
+    }
+
+    var encodingTable = {};
+    for (var i = 0; i < decodingTable.length; i++) {
+        encodingTable[decodingTable.charCodeAt(i)] = i + 0x80;
+    }
+
+    if (macEncodingTableCache) {
+        macEncodingTableCache.set(encoding, encodingTable);
+    }
+
+    return encodingTable;
+};
+
+// Encodes an old-style Macintosh string. Returns a byte array upon success.
+// If the requested encoding is unsupported, or if the input string contains
+// a character that cannot be expressed in the encoding, the function returns
+// 'undefined'.
+encode.MACSTRING = function(str, encoding) {
+    var table = getMacEncodingTable(encoding);
+    if (table === undefined) {
+        return undefined;
+    }
+
+    var result = [];
+    for (var i = 0; i < str.length; i++) {
+        var c = str.charCodeAt(i);
+
+        // In all eight-bit Mac encodings, the characters 0x00..0x7F are
+        // mapped to U+0000..U+007F; we only need to look up the others.
+        if (c >= 0x80) {
+            c = table[c];
+            if (c === undefined) {
+                // str contains a Unicode character that cannot be encoded
+                // in the requested encoding.
+                return undefined;
+            }
+        }
+
+        result.push(c);
+    }
+
+    return result;
+};
+
+sizeOf.MACSTRING = function(str, encoding) {
+    var b = encode.MACSTRING(str, encoding);
+    if (b !== undefined) {
+        return b.length;
+    } else {
+        return 0;
+    }
+};
+
 // Convert a list of values to a CFF INDEX structure.
 // The values should be objects containing name / type / value.
 encode.INDEX = function(l) {
@@ -347,8 +485,12 @@ sizeOf.OP = sizeOf.BYTE;
 var wmm = typeof WeakMap === 'function' && new WeakMap();
 // Convert a list of CharString operations to bytes.
 encode.CHARSTRING = function(ops) {
-    if (wmm && wmm.has(ops)) {
-        return wmm.get(ops);
+    // See encode.MACSTRING for why we don't do "if (wmm && wmm.has(ops))".
+    if (wmm) {
+        var cachedValue = wmm.get(ops);
+        if (cachedValue !== undefined) {
+            return cachedValue;
+        }
     }
 
     var d = [];

--- a/test/types.js
+++ b/test/types.js
@@ -6,7 +6,9 @@ var describe = mocha.describe;
 var it = mocha.it;
 var testutil = require('./testutil.js');
 var hex = testutil.hex;
+var unhex = testutil.unhex;
 var types = require('../src/types.js');
+var decode = types.decode;
 var encode = types.encode;
 var sizeOf = types.sizeOf;
 
@@ -203,6 +205,150 @@ describe('types.js', function() {
         assert.equal(sizeOf.UTF16('\uD83D\uDC04'), 4);
     });
 
+    it('can handle MACSTRING in Central European encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-ce');
+        var data = '42 65 74 F5 74 92 70 75 73';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 9, encoding),
+            'Betűtípus');
+
+        assert.equal(hex(encode.MACSTRING('Betűtípus', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Betűtípus', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Betűtípus 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Betűtípus', encoding), 9);
+        assert.equal(sizeOf.MACSTRING('Betűtípus 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Croatian encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-croatian');
+        var data = 'A9 74 61 6D 70 61 E8';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 7, encoding),
+            'Štampač');
+
+        assert.equal(hex(encode.MACSTRING('Štampač', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Štampač', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Štampač 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Štampač', encoding), 7);
+        assert.equal(sizeOf.MACSTRING('Štampač 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Cyrillic encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-cyrillic');
+        var data = '98 F0 E8 F4 F2 20 46 6F 6F';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 9, encoding),
+            'Шрифт Foo');
+
+        assert.equal(hex(encode.MACSTRING('Шрифт Foo', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Шрифт Foo', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Шрифт 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Шрифт Foo', encoding), 9);
+        assert.equal(sizeOf.MACSTRING('Шрифт 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Greek encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-greek');
+        var data = 'A1 F2 E1 ED ED E1 F4 EF F3 E5 E9 F2 C0 20 2E 85 2E';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 17, encoding),
+            'Γραμματοσειρά .Ö.');
+
+        assert.equal(hex(encode.MACSTRING('Γραμματοσειρά .Ö.', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Γραμματοσειρά .Ö.', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Γραμματοσειρά 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Γραμματοσειρά .Ö.', encoding), 17);
+        assert.equal(sizeOf.MACSTRING('Γραμματοσειρά 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Icelandic encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-icelandic');
+        var data = 'DE 97 72 69 73 64 97 74 74 69 72 20 DF 97 20 61 DD 8E 67';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 19, encoding),
+            'Þórisdóttir þó aðég');
+
+        assert.equal(hex(encode.MACSTRING('Þórisdóttir þó aðég', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Þórisdóttir þó aðég', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Þórisdóttir 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Þórisdóttir þó aðég', encoding), 19);
+        assert.equal(sizeOf.MACSTRING('Þórisdóttir 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Roman encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('macintosh');
+        var data = '86 65 74 6C 69 62 8A 72 67';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 9, encoding),
+            'Üetlibärg');
+
+        assert.equal(hex(encode.MACSTRING('Üetlibärg', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Üetlibärg', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Üetlibärg 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Üetlibärg', encoding), 9);
+        assert.equal(sizeOf.MACSTRING('Üetlibärg 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Romanian encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-romanian');
+        var data = '54 69 70 BE 72 69 72 65';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 8, encoding),
+            'Tipărire');
+
+        assert.equal(hex(encode.MACSTRING('Tipărire', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Tipărire', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Tipărire 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Tipărire', encoding), 8);
+        assert.equal(sizeOf.MACSTRING('Tipărire 字体', encoding), 0);
+    });
+
+    it('can handle MACSTRING in Turkish encoding', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('x-mac-turkish');
+        var data = '42 61 73 DD 6C 6D DD DF';
+
+        assert.equal(
+            decode.MACSTRING(unhex('DE AD BE EF ' + data), 4, 8, encoding),
+            'Basılmış');
+
+        assert.equal(hex(encode.MACSTRING('Basılmış', encoding)), data);  // not in cache
+        assert.equal(hex(encode.MACSTRING('Basılmış', encoding)), data);  // likely cached
+        assert.equal(encode.MACSTRING('Basılmış 字体', encoding), undefined);  // not encodable
+
+        assert.equal(sizeOf.MACSTRING('Basılmış', encoding), 8);
+        assert.equal(sizeOf.MACSTRING('Basılmış 字体', encoding), 0);
+    });
+
+    it('rejects MACSTRING in unsupported encodings', function() {
+        /*jshint -W053 */  // Suppress "Do not use String as a constructor."
+        var encoding = new String('KOI8-R');
+        assert.equal(decode.MACSTRING(unhex('41 42'), 0, 1, encoding), undefined);
+        assert.equal(encode.MACSTRING('AB', encoding), undefined);
+        assert.equal(sizeOf.MACSTRING('AB', encoding), 0);
+    });
+
     it('can handle INDEX', function() {
         assert.equal(hex(encode.INDEX([])), '00 00');
         assert.equal(sizeOf.INDEX([]), 2);
@@ -260,9 +406,9 @@ describe('types.js', function() {
            {name: 'rlineto', type: 'OP', value: 5}
         ];
 
-        // FIXME: The code under test executes different codepaths
-        // depending on whether the Virtual Machine supports WeakMap.
-        // Should we exercise both paths? How to do this?
+        // Because encode.CHARSTRING uses a cache, we call it twice
+        // for testing both the uncached and the (likely) cached case.
+        assert.equal(hex(encode.CHARSTRING(ops)), 'B5 9C 74 05');
         assert.equal(hex(encode.CHARSTRING(ops)), 'B5 9C 74 05');
         assert.equal(sizeOf.CHARSTRING(ops), 4);
     });


### PR DESCRIPTION
Supports only those character encodings that need little data for
conversion. Decoding strings is fast and allocates hardly any memory.
Encoding strings is less cheap, but rarely needed; the necessary
encoding tables get cached in a WeakMap (if the VM supports this).

Fix a race condition in encoding.CHARSTRING (related to WeakMap).