### PR TITLE
Move UTF16 decoding to types

### DIFF
--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -3,7 +3,9 @@
 
 'use strict';
 
-var encode = require('../types').encode;
+var types = require('../types');
+var decode = types.decode;
+var encode = types.encode;
 var parse = require('../parse');
 var table = require('../table');
 
@@ -60,17 +62,10 @@ function parseNameTable(data, start, ltag) {
         // 1 - 0 - 0 : Macintosh, Roman, English
         // 3 - 1 - 0x409 : Windows, Unicode BMP (UCS-2), en-US
         if (platformID === 3 && encodingID === 1 && languageID === 0x409) {
-            var codePoints = [];
-            var length = byteLength / 2;
-            for (var j = 0; j < length; j++, offset += 2) {
-                codePoints[j] = parse.getShort(data, stringOffset + offset);
-            }
-
-            var str = String.fromCharCode.apply(null, codePoints);
+            var str = decode.UTF16(data, stringOffset + offset, byteLength);
             if (property) {
                 name[property] = str;
-            }
-            else {
+            } else {
                 unknownCount++;
                 name['unknown' + unknownCount] = str;
             }

--- a/src/types.js
+++ b/src/types.js
@@ -222,6 +222,16 @@ sizeOf.NAME = sizeOf.CHARARRAY;
 encode.STRING = encode.CHARARRAY;
 sizeOf.STRING = sizeOf.CHARARRAY;
 
+decode.UTF16 = function(data, offset, numBytes) {
+    var codePoints = [];
+    var numChars = numBytes / 2;
+    for (var j = 0; j < numChars; j++, offset += 2) {
+        codePoints[j] = data.getUint16(offset);
+    }
+
+    return String.fromCharCode.apply(null, codePoints);
+};
+
 // Convert a JavaScript string to UTF16-BE.
 encode.UTF16 = function(v) {
     var b = [];

--- a/test/types.js
+++ b/test/types.js
@@ -194,6 +194,7 @@ describe('types.js', function() {
     });
 
     it('can handle UTF16', function() {
+        assert.equal(decode.UTF16(unhex('DE AD 5B 57 4F 53'), 2, 4), '字体');
         assert.equal(hex(encode.UTF16('字体')), '5B 57 4F 53');
         assert.equal(sizeOf.UTF16('字体'), 4);
 
@@ -201,6 +202,7 @@ describe('types.js', function() {
         // are represented with surrogate pairs. For example, U+1F404 COW
         // is stored as the surrogate pair U+D83D U+DC04. This is also
         // exactly what we need for representing U+1F404 in UTF-16.
+        assert.equal(decode.UTF16(unhex('DE AD D8 3D DC 04'), 2, 4), '\uD83D\uDC04');
         assert.equal(hex(encode.UTF16('\uD83D\uDC04')), 'D8 3D DC 04');
         assert.equal(sizeOf.UTF16('\uD83D\uDC04'), 4);
     });


### PR DESCRIPTION
The previous implementation was probably incorrect for codepoints
above U+7FFF, since it was parsing signed 16-bit numbers. The new
version uses unsigned 16-bit integers, and has a unit test.