### PR TITLE
Handle names of font variation axes and instances

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -77,6 +77,7 @@ function parseBuffer(buffer) {
     var ltagTable;
 
     var cffOffset;
+    var fvarOffset;
     var glyfOffset;
     var gposOffset;
     var hmtxOffset;
@@ -116,7 +117,7 @@ function parseBuffer(buffer) {
             font.encoding = new encoding.CmapEncoding(font.tables.cmap);
             break;
         case 'fvar':
-            font.tables.fvar = fvar.parse(data, offset);
+            fvarOffset = offset;
             break;
         case 'head':
             font.tables.head = head.parse(data, offset);
@@ -192,6 +193,10 @@ function parseBuffer(buffer) {
 
     if (gposOffset) {
         gpos.parse(data, gposOffset, font);
+    }
+
+    if (fvarOffset) {
+        font.tables.fvar = fvar.parse(data, fvarOffset, font.names);
     }
 
     return font;

--- a/test/tables/fvar.js
+++ b/test/tables/fvar.js
@@ -22,33 +22,59 @@ describe('tables/fvar.js', function() {
                 minValue: 100,
                 defaultValue: 400,
                 maxValue: 900,
-                nameID: 257
+                name: {en: 'Weight', ja: 'ウエイト'}
             },
             {
                 tag: 'wdth',
                 minValue: 50,
                 defaultValue: 100,
                 maxValue: 200,
-                nameID: 258
+                name: {en: 'Width', ja: '幅'}
             }
         ],
         instances: [
             {
-                nameID: 259,
+                name: {en: 'Regular', ja: 'レギュラー'},
                 coordinates: {wght: 300, wdth: 100}
             },
             {
-                nameID: 260,
+                name: {en: 'Condensed', ja: 'コンデンス'},
                 coordinates: {wght: 300, wdth: 75}
             }
         ]
     };
 
     it('can parse a font variations table', function() {
-        assert.deepEqual(table, fvar.parse(testutil.unhex(data), 0));
+        var names = {
+            257: {en: 'Weight', ja: 'ウエイト'},
+            258: {en: 'Width', ja: '幅'},
+            259: {en: 'Regular', ja: 'レギュラー'},
+            260: {en: 'Condensed', ja: 'コンデンス'}
+        };
+        assert.deepEqual(table, fvar.parse(testutil.unhex(data), 0, names));
     });
 
     it('can make a font variations table', function() {
-        assert.deepEqual(data, testutil.hex(fvar.make(table).encode()));
+        var names = {
+            // When assigning name IDs, numbers below 256 should be ignored,
+            // as these are not valid IDs of ‘fvar’ axis or instance names.
+            111: {en: 'Name #111'},
+
+            // Existing names with ID 256 or higher should be left untouched,
+            // as these can be valid names of font features.
+            256: {en: 'Ligatures', ja: 'リガチャ'},
+
+            // Existing names with ID 256 or higher should be re-used.
+            257: {en: 'Weight', ja: 'ウエイト'}
+        };
+        assert.deepEqual(data, testutil.hex(fvar.make(table, names).encode()));
+        assert.deepEqual(names, {
+            111: {en: 'Name #111'},
+            256: {en: 'Ligatures', ja: 'リガチャ'},
+            257: {en: 'Weight', ja: 'ウエイト'},
+            258: {en: 'Width', ja: '幅'},
+            259: {en: 'Regular', ja: 'レギュラー'},
+            260: {en: 'Condensed', ja: 'コンデンス'}
+        });
     });
 });


### PR DESCRIPTION
Before this change, a client would have to look up the nameID
in the font’s naming table when parsing a font.  Now, the names
are directly available from the axis and instance objects.