### PR TITLE
Fixes #140

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -176,14 +176,14 @@ function parseBuffer(buffer) {
         var shortVersion = indexToLocFormat === 0;
         var locaTable = loca.parse(data, locaOffset, font.numGlyphs, shortVersion);
         font.glyphs = glyf.parse(data, glyfOffset, locaTable, font);
-        hmtx.parse(data, hmtxOffset, font.numberOfHMetrics, font.numGlyphs, font.glyphs);
-        encoding.addGlyphNames(font);
     } else if (cffOffset) {
         cff.parse(data, cffOffset, font);
-        encoding.addGlyphNames(font);
     } else {
         throw new Error('Font doesn\'t contain TrueType or CFF outlines.');
     }
+
+    hmtx.parse(data, hmtxOffset, font.numberOfHMetrics, font.numGlyphs, font.glyphs);
+    encoding.addGlyphNames(font);
 
     if (kernOffset) {
         font.kerningPairs = kern.parse(data, kernOffset);


### PR DESCRIPTION
Fixes #140
The hmtx table was parsed only for TTF fonts. For OTF/CFF fonts, the glyphs advanceWidth was calculated only after lazy-loading of the path, resulting in NaN values.

This may be impacted by #135.