### PR TITLE
Fix regression introduced by #175

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-var check = require('./check');
 var encode = require('./types').encode;
 var sizeOf = require('./types').sizeOf;
 
@@ -27,29 +26,12 @@ function Table(tableName, fields, options) {
     }
 }
 
-Table.prototype.sizeOf = function() {
-    var v = 0;
-    for (var i = 0; i < this.fields.length; i += 1) {
-        var field = this.fields[i];
-        var value = this[field.name];
-        if (value === undefined) {
-            value = field.value;
-        }
-
-        if (typeof value.sizeOf === 'function') {
-            v += value.sizeOf();
-        } else {
-            var sizeOfFunction = sizeOf[field.type];
-            check.assert(typeof sizeOfFunction === 'function', 'Could not find sizeOf function for field' + field.name);
-            v += sizeOfFunction(value);
-        }
-    }
-
-    return v;
-};
-
 Table.prototype.encode = function() {
     return encode.TABLE(this);
 };
 
-exports.Table = Table;
+Table.prototype.sizeOf = function() {
+    return sizeOf.TABLE(this);
+};
+
+exports.Record = exports.Table = Table;

--- a/src/tables/cff.js
+++ b/src/tables/cff.js
@@ -857,7 +857,7 @@ function encodeString(s, strings) {
 }
 
 function makeHeader() {
-    return new table.Table('Header', [
+    return new table.Record('Header', [
         {name: 'major', type: 'Card8', value: 1},
         {name: 'minor', type: 'Card8', value: 0},
         {name: 'hdrSize', type: 'Card8', value: 4},
@@ -866,7 +866,7 @@ function makeHeader() {
 }
 
 function makeNameIndex(fontNames) {
-    var t = new table.Table('Name INDEX', [
+    var t = new table.Record('Name INDEX', [
         {name: 'names', type: 'INDEX', value: []}
     ]);
     t.names = [];
@@ -897,7 +897,7 @@ function makeDict(meta, attrs, strings) {
 
 // The Top DICT houses the global font attributes.
 function makeTopDict(attrs, strings) {
-    var t = new table.Table('Top DICT', [
+    var t = new table.Record('Top DICT', [
         {name: 'dict', type: 'DICT', value: {}}
     ]);
     t.dict = makeDict(TOP_DICT_META, attrs, strings);
@@ -905,7 +905,7 @@ function makeTopDict(attrs, strings) {
 }
 
 function makeTopDictIndex(topDict) {
-    var t = new table.Table('Top DICT INDEX', [
+    var t = new table.Record('Top DICT INDEX', [
         {name: 'topDicts', type: 'INDEX', value: []}
     ]);
     t.topDicts = [{name: 'topDict_0', type: 'TABLE', value: topDict}];
@@ -913,7 +913,7 @@ function makeTopDictIndex(topDict) {
 }
 
 function makeStringIndex(strings) {
-    var t = new table.Table('String INDEX', [
+    var t = new table.Record('String INDEX', [
         {name: 'strings', type: 'INDEX', value: []}
     ]);
     t.strings = [];
@@ -926,13 +926,13 @@ function makeStringIndex(strings) {
 
 function makeGlobalSubrIndex() {
     // Currently we don't use subroutines.
-    return new table.Table('Global Subr INDEX', [
+    return new table.Record('Global Subr INDEX', [
         {name: 'subrs', type: 'INDEX', value: []}
     ]);
 }
 
 function makeCharsets(glyphNames, strings) {
-    var t = new table.Table('Charsets', [
+    var t = new table.Record('Charsets', [
         {name: 'format', type: 'Card8', value: 0}
     ]);
     for (var i = 0; i < glyphNames.length; i += 1) {
@@ -1014,7 +1014,7 @@ function glyphToOps(glyph) {
 }
 
 function makeCharStringsIndex(glyphs) {
-    var t = new table.Table('CharStrings INDEX', [
+    var t = new table.Record('CharStrings INDEX', [
         {name: 'charStrings', type: 'INDEX', value: []}
     ]);
 
@@ -1028,7 +1028,7 @@ function makeCharStringsIndex(glyphs) {
 }
 
 function makePrivateDict(attrs, strings) {
-    var t = new table.Table('Private DICT', [
+    var t = new table.Record('Private DICT', [
         {name: 'dict', type: 'DICT', value: {}}
     ]);
     t.dict = makeDict(PRIVATE_DICT_META, attrs, strings);
@@ -1037,14 +1037,14 @@ function makePrivateDict(attrs, strings) {
 
 function makeCFFTable(glyphs, options) {
     var t = new table.Table('CFF ', [
-        {name: 'header', type: 'TABLE'},
-        {name: 'nameIndex', type: 'TABLE'},
-        {name: 'topDictIndex', type: 'TABLE'},
-        {name: 'stringIndex', type: 'TABLE'},
-        {name: 'globalSubrIndex', type: 'TABLE'},
-        {name: 'charsets', type: 'TABLE'},
-        {name: 'charStringsIndex', type: 'TABLE'},
-        {name: 'privateDict', type: 'TABLE'}
+        {name: 'header', type: 'RECORD'},
+        {name: 'nameIndex', type: 'RECORD'},
+        {name: 'topDictIndex', type: 'RECORD'},
+        {name: 'stringIndex', type: 'RECORD'},
+        {name: 'globalSubrIndex', type: 'RECORD'},
+        {name: 'charsets', type: 'RECORD'},
+        {name: 'charStringsIndex', type: 'RECORD'},
+        {name: 'privateDict', type: 'RECORD'}
     ]);
 
     var fontScale = 1 / options.unitsPerEm;

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -686,7 +686,7 @@ function reverseDict(dict) {
 }
 
 function makeNameRecord(platformID, encodingID, languageID, nameID, length, offset) {
-    return new table.Table('NameRecord', [
+    return new table.Record('NameRecord', [
         {name: 'platformID', type: 'USHORT', value: platformID},
         {name: 'encodingID', type: 'USHORT', value: encodingID},
         {name: 'languageID', type: 'USHORT', value: languageID},
@@ -819,7 +819,7 @@ function makeNameTable(names, ltag) {
     ]);
 
     for (var r = 0; r < nameRecords.length; r++) {
-        t.fields.push({name: 'record_' + r, type: 'TABLE', value: nameRecords[r]});
+        t.fields.push({name: 'record_' + r, type: 'RECORD', value: nameRecords[r]});
     }
 
     t.fields.push({name: 'strings', type: 'LITERAL', value: stringPool});

--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -42,7 +42,7 @@ function computeCheckSum(bytes) {
 }
 
 function makeTableRecord(tag, checkSum, offset, length) {
-    return new table.Table('Table Record', [
+    return new table.Record('Table Record', [
         {name: 'tag', type: 'TAG', value: tag !== undefined ? tag : ''},
         {name: 'checkSum', type: 'ULONG', value: checkSum !== undefined ? checkSum : 0},
         {name: 'offset', type: 'ULONG', value: offset !== undefined ? offset : 0},
@@ -79,8 +79,8 @@ function makeSfntTable(tables) {
         check.argument(t.tableName.length === 4, 'Table name' + t.tableName + ' is invalid.');
         var tableLength = t.sizeOf();
         var tableRecord = makeTableRecord(t.tableName, computeCheckSum(t.encode()), offset, tableLength);
-        recordFields.push({name: tableRecord.tag + ' Table Record', type: 'TABLE', value: tableRecord});
-        tableFields.push({name: t.tableName + ' table', type: 'TABLE', value: t});
+        recordFields.push({name: tableRecord.tag + ' Table Record', type: 'RECORD', value: tableRecord});
+        tableFields.push({name: t.tableName + ' table', type: 'RECORD', value: t});
         offset += tableLength;
         check.argument(!isNaN(offset), 'Something went wrong calculating the offset.');
         while (offset % 4 !== 0) {

--- a/src/types.js
+++ b/src/types.js
@@ -580,6 +580,7 @@ encode.TABLE = function(table) {
         }
 
         var bytes = encodingFunction(value);
+
         if (field.type === 'TABLE') {
             subtableOffsets.push(d.length);
             d = d.concat([0, 0]);
@@ -592,7 +593,7 @@ encode.TABLE = function(table) {
     for (i = 0; i < subtables.length; i += 1) {
         var o = subtableOffsets[i];
         var offset = d.length;
-        check.argument(offset < 65536, 'Table ' + table.name + ' too big.');
+        check.argument(offset < 65536, 'Table ' + table.tableName + ' too big.');
         d[o] = offset >> 8;
         d[o + 1] = offset & 0xff;
         d = d.concat(subtables[i]);
@@ -624,6 +625,9 @@ sizeOf.TABLE = function(table) {
 
     return numBytes;
 };
+
+encode.RECORD = encode.TABLE;
+sizeOf.RECORD = sizeOf.TABLE;
 
 // Merge in a list of bytes.
 encode.LITERAL = function(v) {

--- a/test/types.js
+++ b/test/types.js
@@ -519,6 +519,25 @@ describe('types.js', function() {
         assert.equal(sizeOf.TABLE(table), 58);
     });
 
+    it('can handle RECORD', function() {
+        var table = {
+            fields: [
+                {name: 'version', type: 'FIXED', value: 0x01234567},
+                {name: 'record', type: 'RECORD'}
+            ]
+        };
+
+        table.record = {
+            fields: [
+                {name: 'flags_0', type: 'USHORT', value: 0xDEAF},
+                {name: 'flags_1', type: 'USHORT', value: 0xCAFE}
+            ]
+        };
+
+        assert.equal(hex(encode.TABLE(table)), '01 23 45 67 DE AF CA FE');
+        assert.equal(sizeOf.TABLE(table), 8);
+    });
+
     it('can handle LITERAL', function() {
         assert.equal(hex(encode.LITERAL([])), '');
         assert.equal(sizeOf.LITERAL([]), 0);


### PR DESCRIPTION
This introduces a new class `Record` and the associated type `RECORD`.
It is used to group fields together and provides a `sizeOf` method.

Differences with Table:
* the data is inlined alongside other fields, whereas Table data is stored after all other fields and referenced via an offset.
* this structure is not meant to be recursive
