### PR TITLE
Rename manufacturerURL to vendorURL to follow OpenType specification

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -32,7 +32,7 @@ function Font(options) {
             designer: {en: options.designer || ' '},
             designerURL: {en: options.designerURL || ' '},
             manufacturer: {en: options.manufacturer || ' '},
-            manufacturerURL: {en: options.manufacturerURL || ' '},
+            vendorURL: {en: options.vendorURL || ' '},
             license: {en: options.license || ' '},
             licenseURL: {en: options.licenseURL || ' '},
             version: {en: options.version || 'Version 0.1'},

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -22,7 +22,7 @@ var nameTableNames = [
     'manufacturer',           // 8
     'designer',               // 9
     'description',            // 10
-    'manufacturerURL',        // 11
+    'vendorURL',              // 11
     'designerURL',            // 12
     'license',                // 13
     'licenseURL',             // 14


### PR DESCRIPTION
Hi!

I renamed `manufacturerURL` to `vendorURL` to follow the specification:

`11 URL Vendor; URL of font vendor (with protocol, e.g., http://, ftp://). If a unique serial number is embedded in the URL, it can be used to register the font.`

See https://www.microsoft.com/typography/otspec/name.htm 
