### PR TITLE
Wrapped parseBuffer in a try/catch and added test

### DIFF
--- a/src/opentype.js
+++ b/src/opentype.js
@@ -289,8 +289,12 @@ function load(url, callback) {
         if (err) {
             return callback(err);
         }
-
-        var font = parseBuffer(arrayBuffer);
+        var font;
+        try {
+            font = parseBuffer(arrayBuffer);
+        } catch (e) {
+            return callback(e, null);
+        }
         return callback(null, font);
     });
 }

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -40,6 +40,14 @@ describe('OpenType.js', function() {
         assert.equal(aGlyph.path.commands.length, 14);
     });
 
+    it('handles a parseBuffer error', function(done) {
+        opentype.load('./fonts/华文黑体.ttf', function(err) {
+            if (err) {
+                done();
+            }
+        });
+    });
+
     it('throws an error when advanceWidth is not set', function() {
         var notdefGlyph = new opentype.Glyph({
             name: '.notdef',

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -40,14 +40,6 @@ describe('OpenType.js', function() {
         assert.equal(aGlyph.path.commands.length, 14);
     });
 
-    it('handles a parseBuffer error', function(done) {
-        opentype.load('./fonts/华文黑体.ttf', function(err) {
-            if (err) {
-                done();
-            }
-        });
-    });
-
     it('throws an error when advanceWidth is not set', function() {
         var notdefGlyph = new opentype.Glyph({
             name: '.notdef',


### PR DESCRIPTION
The lib currently crashes when it encounters certain fonts rather than handling the error. I caught parseBuffer errors and passed them into the callback. I also added a test to make sure the error is being handled. I noticed there was another PR meant to fix the same issue, but it has not been touched in over a month and did not include a test, so I thought I would make my own. Thanks!