### PR TITLE
Show cmap.glyphIndexMap object & text wrap output

### DIFF
--- a/font-inspector.html
+++ b/font-inspector.html
@@ -161,6 +161,8 @@ function displayFontData() {
                 html += value.map(function(item) {
                     return JSON.stringify(item);
                 }).join('<br>');
+            } else if (typeof value === 'object') {
+              html += JSON.stringify(value);
             } else {
                 html += value;
             }

--- a/font-inspector.html
+++ b/font-inspector.html
@@ -36,21 +36,21 @@
 
     <div id="font-data">
         <h3 class="collapsed">Font Header table <a href="https://www.microsoft.com/typography/OTSPEC/head.htm" target="_blank">head</a></h3>
-        <dl id="head-table"></dl>
+        <dl id="head-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">Horizontal Header table <a href="https://www.microsoft.com/typography/OTSPEC/hhea.htm" target="_blank">hhea</a></h3>
-        <dl id="hhea-table"></dl>
+        <dl id="hhea-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">Maximum Profile table <a href="https://www.microsoft.com/typography/OTSPEC/maxp.htm" target="_blank">maxp</a></h3>
-        <dl id="maxp-table"></dl>
+        <dl id="maxp-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">Naming table <a href="https://www.microsoft.com/typography/OTSPEC/name.htm" target="_blank">name</a></h3>
-        <dl id="name-table"></dl>
+        <dl id="name-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">OS/2 and Windows Metrics table <a href="https://www.microsoft.com/typography/OTSPEC/os2.htm" target="_blank">OS/2</a></h3>
-        <dl id="os2-table"></dl>
+        <dl id="os2-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">PostScript table <a href="https://www.microsoft.com/typography/OTSPEC/post.htm" target="_blank">post</a></h3>
-        <dl id="post-table"></dl>
+        <dl id="post-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">Character To Glyph Index Mapping Table <a href="https://www.microsoft.com/typography/OTSPEC/cmap.htm" target="_blank">cmap</a></h3>
-        <dl id="cmap-table"></dl>
+        <dl id="cmap-table"><dt>Undefined</dt></dl>
         <h3 class="collapsed">Font Variations table <a href="https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6fvar.html" target="_blank">fvar</a></h3>
-        <dl id="fvar-table"></dl>
+        <dl id="fvar-table"><dt>Undefined</dt></dl>
     </div>
 
     <hr>

--- a/site.css
+++ b/site.css
@@ -189,6 +189,7 @@ a {
 
 #font-data dd {
     margin-left: 12em;
+    word-break: break-all;
 }
 
 #font-data .langtag {


### PR DESCRIPTION
The [font inspector demo](http://opentype.js.org/font-inspector.html) `cmap` currently displays `[object Object]` as the value of `glyphIndexMap`.

This PR replaces that with the actual object & adds `word-break: break-all;` to the css to make all the text wrap. Also, in the `fvar` is usually undefined, so an "Undefined" message is now shown.

Also, in case you're interested, I created [a userscript](https://github.com/Mottie/GitHub-userscripts/wiki/GitHub-font-preview) that uses opentype.js to add a font preview on git font file pages. I blatantly copied the font & glyph inspector code - I hope you guys don't mind.