### PR TITLE
Fix OS/2 usFirstCharIndex

### DIFF
--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -152,8 +152,11 @@ function fontToSfntTable(font) {
             throw new Error('Glyph ' + glyph.name + ' (' + i + '): advanceWidth is required.');
         }
 
-        if (firstCharIndex > unicode || firstCharIndex === null) {
-            firstCharIndex = unicode;
+        if (firstCharIndex > unicode || firstCharIndex === undefined) {
+            // ignore .notdef char
+            if (unicode > 0) {
+                firstCharIndex = unicode;
+            }
         }
 
         if (lastCharIndex < unicode) {


### PR DESCRIPTION
Hi 😉

I just fixed a bug with the usFirstCharIndex see reports from Microsoft's Font Validator:
![screenshot 2016-06-22 at 15 49 19](https://cloud.githubusercontent.com/assets/1328733/16269058/1aa044b8-3891-11e6-9ccd-063953d40bf6.jpg)
`E2130 	The usFirstCharIndex is not valid -	actual = 0x0000, calculated = 0x0020`

After fixing it:
`P2100 	The usFirstCharIndex and usLastCharIndex fields are valid -  first = 0x0020, last = 0x005f`