### PR TITLE
Better errors!

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -320,7 +320,7 @@ Font.prototype.download = function() {
             });
         },
         function(err) {
-            throw err;
+            throw new Error(err.name + ': ' + err.message);
         });
     } else {
         var fs = require('fs');

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -744,6 +744,11 @@ function makeNameTable(names, ltag) {
         }
 
         nameID = parseInt(id);
+
+        if (isNaN(nameID)) {
+            throw new Error('Name table entry "' + key + '" does not exist, see nameTableNames for complete list.');
+        }
+
         namesWithNumericKeys[nameID] = names[key];
         nameIDs.push(nameID);
     }


### PR DESCRIPTION
I added an error when a name table entry is not existing, like doing a typo an a name: ~~fontSubFamily~~ (typo on uppercase F), the good name is "fontSubfamily"!
Before throwing the error the font was still looking "good" so it was a nightmare to debug it!

\+ Improve throw error message of Font.download()

Before
![screenshot 2016-06-23 at 12 52 07](https://cloud.githubusercontent.com/assets/1328733/16300707/975d23e4-3941-11e6-967a-f51b70dfd7f2.jpg)
After
![screenshot 2016-06-23 at 12 52 22](https://cloud.githubusercontent.com/assets/1328733/16300710/9d7d4a2e-3941-11e6-9720-5d8d4b55b6ab.jpg)

