### PR TITLE
Parse GSUB table

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jscs": "^3.0.3",
     "jshint": "^2.9.2",
     "mkdirp": "^0.5.1",
-    "mocha": "^2.4.5",
+    "mocha": "^2.5.3",
     "parallelshell": "^2.0.0",
     "rimraf": "^2.5.2",
     "uglifyify": "^3.0.1",

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -21,6 +21,7 @@ var cff = require('./tables/cff');
 var fvar = require('./tables/fvar');
 var glyf = require('./tables/glyf');
 var gpos = require('./tables/gpos');
+var gsub = require('./tables/gsub');
 var head = require('./tables/head');
 var hhea = require('./tables/hhea');
 var hmtx = require('./tables/hmtx');
@@ -163,6 +164,7 @@ function parseBuffer(buffer) {
     var fvarTableEntry;
     var glyfTableEntry;
     var gposTableEntry;
+    var gsubTableEntry;
     var hmtxTableEntry;
     var kernTableEntry;
     var locaTableEntry;
@@ -232,6 +234,9 @@ function parseBuffer(buffer) {
             case 'GPOS':
                 gposTableEntry = tableEntry;
                 break;
+            case 'GSUB':
+                gsubTableEntry = tableEntry;
+                break;
         }
     }
 
@@ -266,6 +271,10 @@ function parseBuffer(buffer) {
     if (gposTableEntry) {
         var gposTable = uncompressTable(data, gposTableEntry);
         gpos.parse(gposTable.data, gposTable.offset, font);
+    }
+    if (gsubTableEntry) {
+        var gsubTable = uncompressTable(data, gsubTableEntry);
+        font.tables.gsub = gsub.parse(gsubTable.data, gsubTable.offset);
     }
 
     if (fvarTableEntry) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+var check = require('./check');
+
 // Retrieve an unsigned byte from the DataView.
 exports.getByte = function getByte(dataView, offset) {
     return dataView.getUint8(offset);
@@ -11,11 +13,11 @@ exports.getCard8 = exports.getByte;
 
 // Retrieve an unsigned 16-bit short from the DataView.
 // The value is stored in big endian.
-exports.getUShort = function(dataView, offset) {
+function getUShort(dataView, offset) {
     return dataView.getUint16(offset, false);
-};
+}
 
-exports.getCard16 = exports.getUShort;
+exports.getUShort = exports.getCard16 = getUShort;
 
 // Retrieve a signed 16-bit short from the DataView.
 // The value is stored in big endian.
@@ -146,20 +148,6 @@ Parser.prototype.parseFixed = function() {
     return v;
 };
 
-Parser.prototype.parseOffset16List =
-Parser.prototype.parseUShortList = function(count) {
-    var offsets = new Array(count);
-    var dataView = this.data;
-    var offset = this.offset + this.relativeOffset;
-    for (var i = 0; i < count; i++) {
-        offsets[i] = exports.getUShort(dataView, offset);
-        offset += 2;
-    }
-
-    this.relativeOffset += count * 2;
-    return offsets;
-};
-
 Parser.prototype.parseString = function(length) {
     var dataView = this.data;
     var offset = this.offset + this.relativeOffset;
@@ -182,25 +170,19 @@ Parser.prototype.parseTag = function() {
 // + Since until 2038 those bits will be filled by zeros we can ignore them.
 Parser.prototype.parseLongDateTime = function() {
     var v = exports.getULong(this.data, this.offset + this.relativeOffset + 4);
-    // Substract seconds between 01/01/1904 and 01/01/1970
+    // Subtract seconds between 01/01/1904 and 01/01/1970
     // to convert Apple Mac timstamp to Standard Unix timestamp
     v -= 2082844800;
     this.relativeOffset += 8;
     return v;
 };
 
-Parser.prototype.parseFixed = function() {
-    var v = exports.getULong(this.data, this.offset + this.relativeOffset);
-    this.relativeOffset += 4;
-    return v / 65536;
-};
-
 Parser.prototype.parseVersion = function() {
-    var major = exports.getUShort(this.data, this.offset + this.relativeOffset);
+    var major = getUShort(this.data, this.offset + this.relativeOffset);
 
     // How to interpret the minor version is very vague in the spec. 0x5000 is 5, 0x1000 is 1
     // This returns the correct number if minor = 0xN000 where N is 0-9
-    var minor = exports.getUShort(this.data, this.offset + this.relativeOffset + 2);
+    var minor = getUShort(this.data, this.offset + this.relativeOffset + 2);
     this.relativeOffset += 4;
     return major + minor / 0x1000 / 10;
 };
@@ -211,6 +193,257 @@ Parser.prototype.skip = function(type, amount) {
     }
 
     this.relativeOffset += typeOffsets[type] * amount;
+};
+
+///// Parsing lists and records ///////////////////////////////
+
+// Parse a list of 16 bit integers. The length of the list can be read on the stream
+// or provided as an argument.
+Parser.prototype.parseOffset16List =
+Parser.prototype.parseUShortList = function(count) {
+    if (count === undefined) { count = this.parseUShort(); }
+    var offsets = new Array(count);
+    var dataView = this.data;
+    var offset = this.offset + this.relativeOffset;
+    for (var i = 0; i < count; i++) {
+        offsets[i] = dataView.getUint16(offset);
+        offset += 2;
+    }
+
+    this.relativeOffset += count * 2;
+    return offsets;
+};
+
+/**
+ * Parse a list of items.
+ * Record count is optional, if omitted it is read from the stream.
+ * itemCallback is one of the Parser methods.
+ */
+Parser.prototype.parseList = function(count, itemCallback) {
+    if (!itemCallback) {
+        itemCallback = count;
+        count = this.parseUShort();
+    }
+    var list = new Array(count);
+    for (var i = 0; i < count; i++) {
+        list[i] = itemCallback.call(this);
+    }
+    return list;
+};
+
+/**
+ * Parse a list of records.
+ * Record count is optional, if omitted it is read from the stream.
+ * Example of recordDescription: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+ */
+Parser.prototype.parseRecordList = function(count, recordDescription) {
+    // If the count argument is absent, read it in the stream.
+    if (!recordDescription) {
+        recordDescription = count;
+        count = this.parseUShort();
+    }
+    var records = new Array(count);
+    var fields = Object.keys(recordDescription);
+    for (var i = 0; i < count; i++) {
+        var rec = {};
+        for (var j = 0; j < fields.length; j++) {
+            var fieldName = fields[j];
+            var fieldType = recordDescription[fieldName];
+            rec[fieldName] = fieldType.call(this);
+        }
+        records[i] = rec;
+    }
+    return records;
+};
+
+// Parse a data structure into an object
+// Example of description: { sequenceIndex: Parser.uShort, lookupListIndex: Parser.uShort }
+Parser.prototype.parseStruct = function(description) {
+    if (typeof description === 'function') {
+        return description.call(this);
+    } else {
+        var fields = Object.keys(description);
+        var struct = {};
+        for (var j = 0; j < fields.length; j++) {
+            var fieldName = fields[j];
+            var fieldType = description[fieldName];
+            struct[fieldName] = fieldType.call(this);
+        }
+        return struct;
+    }
+};
+
+Parser.prototype.parsePointer = function(description) {
+    var structOffset = this.parseOffset16();
+    if (structOffset > 0) {                         // NULL offset => return indefined
+        return new Parser(this.data, this.offset + structOffset).parseStruct(description);
+    }
+};
+
+/**
+ * Parse a list of offsets to lists of 16-bit integers,
+ * or a list of offsets to lists of offsets to any kind of items.
+ * If itemCallback is not provided, a list of list of UShort is assumed.
+ * If provided, itemCallback is called on each item and must parse the item.
+ * See examples in tables/gsub.js
+ */
+Parser.prototype.parseListOfLists = function(itemCallback) {
+    var offsets = this.parseOffset16List();
+    var count = offsets.length;
+    var relativeOffset = this.relativeOffset;
+    var list = new Array(count);
+    for (var i = 0; i < count; i++) {
+        var start = offsets[i];
+        if (start === 0) {                  // NULL offset
+            list[i] = undefined;            // Add i as owned property to list. Convenient with assert.
+            continue;
+        }
+        this.relativeOffset = start;
+        if (itemCallback) {
+            var subOffsets = this.parseOffset16List();
+            var subList = new Array(subOffsets.length);
+            for (var j = 0; j < subOffsets.length; j++) {
+                this.relativeOffset = start + subOffsets[j];
+                subList[j] = itemCallback.call(this);
+            }
+            list[i] = subList;
+        } else {
+            list[i] = this.parseUShortList();
+        }
+    }
+    this.relativeOffset = relativeOffset;
+    return list;
+};
+
+///// Complex tables parsing //////////////////////////////////
+
+// Parse a coverage table in a GSUB, GPOS or GDEF table.
+// https://www.microsoft.com/typography/OTSPEC/chapter2.htm
+// parser.offset must point to the start of the table containing the coverage.
+Parser.prototype.parseCoverage = function() {
+    var startOffset = this.offset + this.relativeOffset;
+    var format = this.parseUShort();
+    var count = this.parseUShort();
+    if (format === 1) {
+        return {
+            format: 1,
+            glyphs: this.parseUShortList(count)
+        };
+    } else if (format === 2) {
+        var ranges = new Array(count);
+        for (var i = 0; i < count; i++) {
+            ranges[i] = {
+                start: this.parseUShort(),
+                end: this.parseUShort(),
+                index: this.parseUShort()
+            };
+        }
+        return {
+            format: 2,
+            ranges: ranges
+        };
+    }
+    check.assert(false, '0x' + startOffset.toString(16) + ': Coverage format must be 1 or 2.');
+};
+
+// Parse a Class Definition Table in a GSUB, GPOS or GDEF table.
+// https://www.microsoft.com/typography/OTSPEC/chapter2.htm
+Parser.prototype.parseClassDef = function() {
+    var startOffset = this.offset + this.relativeOffset;
+    var format = this.parseUShort();
+    if (format === 1) {
+        return {
+            format: 1,
+            startGlyph: this.parseUShort(),
+            classes: this.parseUShortList()
+        };
+    } else if (format === 2) {
+        return {
+            format: 2,
+            ranges: this.parseRecordList({
+                start: Parser.uShort,
+                end: Parser.uShort,
+                classId: Parser.uShort
+            })
+        };
+    }
+    check.assert(false, '0x' + startOffset.toString(16) + ': ClassDef format must be 1 or 2.');
+};
+
+///// Static methods ///////////////////////////////////
+// These convenience methods can be used as callbacks and should be called with "this" context set to a Parser instance.
+
+Parser.list = function(count, itemCallback) {
+    return function() {
+        return this.parseList(count, itemCallback);
+    };
+};
+
+Parser.recordList = function(count, recordDescription) {
+    return function() {
+        return this.parseRecordList(count, recordDescription);
+    };
+};
+
+Parser.pointer = function(description) {
+    return function() {
+        return this.parsePointer(description);
+    };
+};
+
+Parser.tag = Parser.prototype.parseTag;
+Parser.byte = Parser.prototype.parseByte;
+Parser.uShort = Parser.offset16 = Parser.prototype.parseUShort;
+Parser.uShortList = Parser.prototype.parseUShortList;
+Parser.struct = Parser.prototype.parseStruct;
+Parser.coverage = Parser.prototype.parseCoverage;
+Parser.classDef = Parser.prototype.parseClassDef;
+
+///// Script, Feature, Lookup lists ///////////////////////////////////////////////
+// https://www.microsoft.com/typography/OTSPEC/chapter2.htm
+
+var langSysTable = {
+    reserved: Parser.uShort,
+    reqFeatureIndex: Parser.uShort,
+    featureIndexes: Parser.uShortList
+};
+
+Parser.prototype.parseScriptList = function() {
+    return this.parsePointer(Parser.recordList({
+        tag: Parser.tag,
+        script: Parser.pointer({
+            defaultLangSys: Parser.pointer(langSysTable),
+            langSysRecords: Parser.recordList({
+                tag: Parser.tag,
+                langSys: Parser.pointer(langSysTable)
+            })
+        })
+    }));
+};
+
+Parser.prototype.parseFeatureList = function() {
+    return this.parsePointer(Parser.recordList({
+        tag: Parser.tag,
+        feature: Parser.pointer({
+            featureParams: Parser.offset16,
+            lookupListIndexes: Parser.uShortList
+        })
+    }));
+};
+
+Parser.prototype.parseLookupList = function(lookupTableParsers) {
+    return this.parsePointer(Parser.list(Parser.pointer(function() {
+        var lookupType = this.parseUShort();
+        check.argument(1 <= lookupType && lookupType <= 8, 'GSUB lookup type ' + lookupType + ' unknown.');
+        var lookupFlag = this.parseUShort();
+        var useMarkFilteringSet = lookupFlag & 0x10;
+        return {
+            lookupType: lookupType,
+            lookupFlag: lookupFlag,
+            subtables: this.parseList(Parser.pointer(lookupTableParsers[lookupType])),
+            markFilteringSet: useMarkFilteringSet ? this.parseUShort() : undefined
+        };
+    })));
 };
 
 exports.Parser = Parser;

--- a/src/tables/gsub.js
+++ b/src/tables/gsub.js
@@ -1,0 +1,204 @@
+// The `GSUB` table contains ligatures, among other things.
+// https://www.microsoft.com/typography/OTSPEC/gsub.htm
+
+'use strict';
+
+var check = require('../check');
+var Parser = require('../parse').Parser;
+var subtableParsers = new Array(9);         // subtableParsers[0] is unused
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#SS
+subtableParsers[1] = function parseLookup1() {
+    var start = this.offset + this.relativeOffset;
+    var substFormat = this.parseUShort();
+    if (substFormat === 1) {
+        return {
+            substFormat: 1,
+            coverage: this.parsePointer(Parser.coverage),
+            deltaGlyphId: this.parseUShort()
+        };
+    } else if (substFormat === 2) {
+        return {
+            substFormat: 2,
+            coverage: this.parsePointer(Parser.coverage),
+            substitute: this.parseOffset16List()
+        };
+    }
+    check.assert(false, '0x' + start.toString(16) + ': lookup type 1 format must be 1 or 2.');
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#MS
+subtableParsers[2] = function parseLookup2() {
+    var substFormat = this.parseUShort();
+    check.argument(substFormat === 1, 'GSUB Multiple Substitution Subtable identifier-format must be 1');
+    return {
+        substFormat: substFormat,
+        coverage: this.parsePointer(Parser.coverage),
+        sequences: this.parseListOfLists()
+    };
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#AS
+subtableParsers[3] = function parseLookup3() {
+    var substFormat = this.parseUShort();
+    check.argument(substFormat === 1, 'GSUB Alternate Substitution Subtable identifier-format must be 1');
+    return {
+        substFormat: substFormat,
+        coverage: this.parsePointer(Parser.coverage),
+        alternateSets: this.parseListOfLists()
+    };
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#LS
+subtableParsers[4] = function parseLookup4() {
+    var substFormat = this.parseUShort();
+    check.argument(substFormat === 1, 'GSUB ligature table identifier-format must be 1');
+    return {
+        substFormat: substFormat,
+        coverage: this.parsePointer(Parser.coverage),
+        ligatureSets: this.parseListOfLists(function() {
+            return {
+                ligGlyph: this.parseUShort(),
+                components: this.parseUShortList(this.parseUShort() - 1)
+            };
+        })
+    };
+};
+
+var lookupRecordDesc = {
+    sequenceIndex: Parser.uShort,
+    lookupListIndex: Parser.uShort
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#CSF
+subtableParsers[5] = function parseLookup5() {
+    var start = this.offset + this.relativeOffset;
+    var substFormat = this.parseUShort();
+
+    if (substFormat === 1) {
+        return {
+            substFormat: substFormat,
+            coverage: this.parsePointer(Parser.coverage),
+            ruleSets: this.parseListOfLists(function() {
+                var glyphCount = this.parseUShort();
+                var substCount = this.parseUShort();
+                return {
+                    input: this.parseUShortList(glyphCount - 1),
+                    lookupRecords: this.parseRecordList(substCount, lookupRecordDesc)
+                };
+            })
+        };
+    } else if (substFormat === 2) {
+        return {
+            substFormat: substFormat,
+            coverage: this.parsePointer(Parser.coverage),
+            classDef: this.parsePointer(Parser.classDef),
+            classSets: this.parseListOfLists(function() {
+                var glyphCount = this.parseUShort();
+                var substCount = this.parseUShort();
+                return {
+                    classes: this.parseUShortList(glyphCount - 1),
+                    lookupRecords: this.parseRecordList(substCount, lookupRecordDesc)
+                };
+            })
+        };
+    } else if (substFormat === 3) {
+        var glyphCount = this.parseUShort();
+        var substCount = this.parseUShort();
+        return {
+            substFormat: substFormat,
+            coverages: this.parseList(glyphCount, Parser.pointer(Parser.coverage)),
+            lookupRecords: this.parseRecordList(substCount, lookupRecordDesc)
+        };
+    }
+    check.assert(false, '0x' + start.toString(16) + ': lookup type 5 format must be 1, 2 or 3.');
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#CC
+subtableParsers[6] = function parseLookup6() {
+    // TODO add automated tests for lookup 6 : no examples in the MS doc.
+    var start = this.offset + this.relativeOffset;
+    var substFormat = this.parseUShort();
+    if (substFormat === 1) {
+        return {
+            substFormat: 1,
+            coverage: this.parsePointer(Parser.coverage),
+            chainRuleSets: this.parseListOfLists(function() {
+                return {
+                    backtrack: this.parseUShortList(),
+                    input: this.parseUShortList(this.parseShort() - 1),
+                    lookahead: this.parseUShortList(),
+                    lookupRecords: this.parseRecordList(lookupRecordDesc)
+                };
+            })
+        };
+    } else if (substFormat === 2) {
+        return {
+            substFormat: 2,
+            coverage: this.parsePointer(Parser.coverage),
+            backtrackClassDef: this.parsePointer(Parser.classDef),
+            inputClassDef: this.parsePointer(Parser.classDef),
+            lookaheadClassDef: this.parsePointer(Parser.classDef),
+            chainClassSet: this.parseListOfLists(function() {
+                return {
+                    backtrack: this.parseUShortList(),
+                    input: this.parseUShortList(this.parseShort() - 1),
+                    lookahead: this.parseUShortList(),
+                    lookupRecords: this.parseRecordList(lookupRecordDesc)
+                };
+            })
+        };
+    } else if (substFormat === 3) {
+        return {
+            substFormat: 3,
+            backtrackCoverage: this.parseList(Parser.pointer(Parser.coverage)),
+            inputCoverage: this.parseList(Parser.pointer(Parser.coverage)),
+            lookaheadCoverage: this.parseList(Parser.pointer(Parser.coverage)),
+            lookupRecords: this.parseRecordList(lookupRecordDesc)
+        };
+    }
+    check.assert(false, '0x' + start.toString(16) + ': lookup type 6 format must be 1, 2 or 3.');
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#ES
+subtableParsers[7] = function parseLookup7() {
+    // Extension Substitution subtable
+    var substFormat = this.parseUShort();
+    check.argument(substFormat === 1, 'GSUB Extension Substitution subtable identifier-format must be 1');
+    var extensionLookupType = this.parseUShort();
+    var extensionParser = new Parser(this.data, this.offset + this.parseULong());
+    return {
+        substFormat: 1,
+        lookupType: extensionLookupType,
+        extension: subtableParsers[extensionLookupType].call(extensionParser)
+    };
+};
+
+// https://www.microsoft.com/typography/OTSPEC/GSUB.htm#RCCS
+subtableParsers[8] = function parseLookup8() {
+    var substFormat = this.parseUShort();
+    check.argument(substFormat === 1, 'GSUB Reverse Chaining Contextual Single Substitution Subtable identifier-format must be 1');
+    return {
+        substFormat: substFormat,
+        coverage: this.parsePointer(Parser.coverage),
+        backtrackCoverage: this.parseList(Parser.pointer(Parser.coverage)),
+        lookaheadCoverage: this.parseList(Parser.pointer(Parser.coverage)),
+        substitutes: this.parseUShortList()
+    };
+};
+
+// https://www.microsoft.com/typography/OTSPEC/gsub.htm
+function parseGsubTable(data, start) {
+    start = start || 0;
+    var p = new Parser(data, start);
+    var tableVersion = p.parseVersion();
+    check.argument(tableVersion === 1, 'Unsupported GSUB table version.');
+    return {
+        version: tableVersion,
+        scripts: p.parseScriptList(),
+        features: p.parseFeatureList(),
+        lookups: p.parseLookupList(subtableParsers)
+    };
+}
+
+exports.parse = parseGsubTable;

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,0 +1,245 @@
+/* jshint mocha: true */
+
+'use strict';
+
+var assert = require('assert');
+var testutil = require('./testutil.js');
+var Parser = require('../src/parse.js').Parser;
+
+describe('parse.js', function() {
+
+    describe('parseUShortList', function() {
+        it('can parse an empty list', function() {
+            var p = new Parser(testutil.unhex('0000'), 0);
+            assert.deepEqual(p.parseUShortList(), []);
+        });
+
+        it('can parse a list', function() {
+            var p = new Parser(testutil.unhex('0003 1234 DEAD BEEF'), 0);
+            assert.deepEqual(p.parseUShortList(), [0x1234, 0xdead, 0xbeef]);
+        });
+
+        it('can parse a list of predefined length', function() {
+            var p = new Parser(testutil.unhex('1234 DEAD BEEF 5678 9ABC'), 2);
+            assert.deepEqual(p.parseUShortList(3), [0xdead, 0xbeef, 0x5678]);
+        });
+    });
+
+    describe('parseList', function() {
+        it('can parse a list of values', function() {
+            var data = '0003 12 34 56 78 9A BC';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseList(Parser.uShort), [0x1234, 0x5678, 0x9abc]);
+            assert.equal(p.relativeOffset, 8);
+        });
+
+        it('can parse a list of values of predefined length', function() {
+            var data = '12 34 56 78 9A BC';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseList(3, Parser.uShort), [0x1234, 0x5678, 0x9abc]);
+            assert.equal(p.relativeOffset, 6);
+        });
+    });
+
+    describe('parseRecordList', function() {
+        it('can parse a list of records', function() {
+            var data = '0002 12 34 56 78 9A BC';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseRecordList({ a: Parser.byte, b: Parser.uShort }), [
+                { a: 0x12, b: 0x3456 },
+                { a: 0x78, b: 0x9abc }
+            ]);
+            assert.equal(p.relativeOffset, 8);
+        });
+
+        it('can parse an empty list of records', function() {
+            var data = '0000';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseRecordList({ a: Parser.byte, b: Parser.uShort }), []);
+            assert.equal(p.relativeOffset, 2);
+        });
+
+        it('can parse a list of records of predefined length', function() {
+            var data = '12 34 56 78 9A BC';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseRecordList(2, { a: Parser.byte, b: Parser.uShort }), [
+                { a: 0x12, b: 0x3456 },
+                { a: 0x78, b: 0x9abc }
+            ]);
+            assert.equal(p.relativeOffset, 6);
+        });
+    });
+
+    describe('parseListOfLists', function() {
+        it('can parse a list of lists of 16-bit integers', function() {
+            var data = '0003 0008 000E 0016' +      // 3 lists
+                '0002 1234 5678' +                  // list 1
+                '0003 DEAD BEEF FADE' +             // list 2
+                '0001 9876';                        // list 3
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseListOfLists(), [
+                [0x1234, 0x5678],
+                [0xdead, 0xbeef, 0xfade],
+                [0x9876]
+            ]);
+        });
+
+        it('can parse an empty list of lists', function() {
+            var p = new Parser(testutil.unhex('0000'), 0);
+            assert.deepEqual(p.parseListOfLists(), []);
+        });
+
+        it('can parse list of empty lists', function() {
+            var p = new Parser(testutil.unhex('0001 0004 0000'), 0);
+            assert.deepEqual(p.parseListOfLists(), [[]]);
+        });
+
+        it('can parse a list of lists of records', function() {
+            var data = '0002 0006 0012' +                   // 2 lists
+                '0002 0006 0009 12 34 56 78 9A BC' +        // list 1
+                '0001 0004 DE F0 12';                       // list 2
+
+            var p = new Parser(testutil.unhex(data), 0);
+            function parseRecord() {
+                return { a: p.parseByte(), b: p.parseUShort() };
+            }
+
+            assert.deepEqual(p.parseListOfLists(parseRecord), [
+                [{ a: 0x12, b: 0x3456 }, { a: 0x78, b: 0x9abc }],
+                [{ a: 0xde, b: 0xf012 }]
+            ]);
+        });
+    });
+
+    describe('parseCoverage', function() {
+        it('should parse a CoverageFormat1 table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 5
+            var data = '0004 1234' +                // coverageOffset + filler
+                '0001 0005 0038 003B 0041 0042 004A';
+            var p = new Parser(testutil.unhex(data), 4);
+            assert.deepEqual(p.parseCoverage(), {
+                format: 1,
+                glyphs: [0x38, 0x3b, 0x41, 0x42, 0x4a]
+            });
+            assert.equal(p.relativeOffset, 14);
+        });
+
+        it('should parse a CoverageFormat2 table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 6
+            var data = '0004 1234' +                // coverageOffset + filler
+                '0002 0001 004E 0057 0000';
+            var p = new Parser(testutil.unhex(data), 4);
+            assert.deepEqual(p.parseCoverage(), {
+                format: 2,
+                ranges: [{ start: 0x4e, end: 0x57, index: 0 }]
+            });
+            assert.equal(p.relativeOffset, 10);
+        });
+    });
+
+    describe('parseClassDef', function() {
+        it('should parse a ClassDefFormat1 table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 7
+            var data = '0001 0032 001A' +
+                '0000 0001 0000 0001 0000 0001 0002 0001 0000 0002 0001 0001 0000' +
+                '0000 0000 0002 0002 0000 0000 0001 0000 0000 0000 0000 0002 0001';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseClassDef(), {
+                format: 1,
+                startGlyph: 0x32,
+                classes: [
+                    0, 1, 0, 1, 0, 1, 2, 1, 0, 2, 1, 1, 0,
+                    0, 0, 2, 2, 0, 0, 1, 0, 0, 0, 0, 2, 1
+                ]
+            });
+            assert.equal(p.relativeOffset, 58);
+        });
+
+        it('should parse a ClassDefFormat2 table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 8
+            var data = '0002 0003 0030 0031 0002 0040 0041 0003 00D2 00D3 0001';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseClassDef(), {
+                format: 2,
+                ranges: [
+                    { start: 0x30, end: 0x31, classId: 2 },
+                    { start: 0x40, end: 0x41, classId: 3 },
+                    { start: 0xd2, end: 0xd3, classId: 1 }
+                ]
+            });
+            assert.equal(p.relativeOffset, 22);
+        });
+    });
+
+    describe('parseScriptList', function() {
+        it('should parse a ScriptList table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Examples 1 & 2
+            var data = '0004 1234' +                // coverageOffset + filler
+                '0003 68616E69 0014 6B616E61 0018 6C61746E 001C' +  // Example 1
+                '0000 0000 0000 0000' +                             // 2 empty Script Tables
+                '000A 0001 55524420 0016' +                         // Example 2
+                '0000 FFFF 0003 0000 0001 0002' +                   // DefLangSys
+                '0000 0003 0003 0000 0001 0002';                    // UrduLangSys
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseScriptList(), [
+                { tag: 'hani', script: { defaultLangSys: undefined, langSysRecords: [] } },
+                { tag: 'kana', script: { defaultLangSys: undefined, langSysRecords: [] } },
+                { tag: 'latn', script: {
+                    defaultLangSys: {
+                        reserved: 0,
+                        reqFeatureIndex: 0xffff,
+                        featureIndexes: [0, 1, 2]
+                    },
+                    langSysRecords: [{
+                        tag: 'URD ',
+                        langSys: {
+                            reserved: 0,
+                            reqFeatureIndex: 3,
+                            featureIndexes: [0, 1, 2]
+                        }
+                    }]
+                } },
+            ]);
+            assert.equal(p.relativeOffset, 2);
+        });
+    });
+
+    describe('parseFeatureList', function() {
+        it('should parse a FeatureList table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 3
+            var data = '0004 0000' +                                // table offset + filler
+                '0003 6C696761 0014 6C696761 001A 6C696761 0022' +  // feature list
+                // There is an error in the online example, count is 3 for the 3rd feature.
+                '0000 0001 0000   0000 0002 0000 0001   0000 0003 0000 0001 0002';
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseFeatureList(), [
+                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0] } },
+                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0, 1] } },
+                { tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0, 1, 2] } }
+            ]);
+            assert.equal(p.relativeOffset, 2);
+        });
+    });
+
+    describe('parseLookupList', function() {
+        it('should parse a LookupList table', function() {
+            // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 4
+            var data = '0004 0000' +                    // table offset + filler
+                '0003 0008 0010 0018' +                 // lookup list
+                '0004 000C 0001 0018' +                 // FfiFi lookup
+                '0004 000C 0001 0028' +                 // FflFlFf lookup
+                '0004 000C 0001 0038' +                 // Eszet lookup
+                '1234 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000' +
+                '5678 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000' +
+                '9ABC';
+            var lookupTableParsers = [0, 0, 0, 0, Parser.uShort];
+            var p = new Parser(testutil.unhex(data), 0);
+            assert.deepEqual(p.parseLookupList(lookupTableParsers), [
+                { lookupType: 4, lookupFlag: 0x000c, subtables: [0x1234], markFilteringSet: undefined },
+                { lookupType: 4, lookupFlag: 0x000c, subtables: [0x5678], markFilteringSet: undefined },
+                { lookupType: 4, lookupFlag: 0x000c, subtables: [0x9abc], markFilteringSet: undefined },
+            ]);
+            assert.equal(p.relativeOffset, 2);
+        });
+    });
+});

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -1,0 +1,233 @@
+/* jshint mocha: true */
+
+'use strict';
+
+var assert = require('assert');
+var testutil = require('../testutil.js');
+var gsub = require('../../src/tables/gsub.js');
+
+// Helper that builds a minimal GSUB table to test a lookup subtable.
+function parseLookup(lookupType, subTableData) {
+    var data = testutil.unhex('00010000 000A 000C 000E' +   // header
+        '0000' +                                        // ScriptTable - 0 scripts
+        '0000' +                                        // FeatureListTable - 0 features
+        '0001 0004' +                                   // LookupListTable - 1 lookup table
+        '000' + lookupType + '0000 0001 0008' +         // Lookup table - 1 subtable
+        subTableData);                                  // sub table start offset: 0x1a
+    return gsub.parse(data).lookups[0].subtables[0];
+}
+
+describe('tables/gsub.js', function() {
+
+    //// Header ///////////////////////////////////////////////////////////////
+    it('can parse a GSUB header', function() {
+        var data = testutil.unhex(
+            '00010000 000A 000C 000E' +     // header
+            '0000' +                        // ScriptTable - 0 scripts
+            '0000' +                        // FeatureListTable - 0 features
+            '0000'                          // LookupListTable - 0 lookups
+        );
+        assert.deepEqual(gsub.parse(data), { version: 1, scripts: [], features: [], lookups: [] });
+    });
+
+    //// Lookup type 1 ////////////////////////////////////////////////////////
+    it('can parse lookup1 substFormat 1', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX2
+        var data = '0001 0006 00C0   0002 0001 004E 0058 0000';
+        assert.deepEqual(parseLookup(1, data), {
+            substFormat: 1,
+            coverage: {
+                format: 2,
+                ranges: [{ start: 0x4e, end: 0x58, index: 0 }]
+            },
+            deltaGlyphId: 0xc0
+        });
+    });
+
+    it('can parse lookup1 substFormat 2', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX3
+        var data = '0002 000E 0004 0131 0135 013E 0143   0001 0004 003C 0040 004B 004F';
+        assert.deepEqual(parseLookup(1, data), {
+            substFormat: 2,
+            coverage: {
+                format: 1,
+                glyphs: [0x3c, 0x40, 0x4b, 0x4f]
+            },
+            substitute: [0x131, 0x135, 0x13E, 0x143]
+        });
+    });
+
+    //// Lookup type 2 ////////////////////////////////////////////////////////
+    it('can parse lookup2', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX4
+        var data = '0001 0008 0001 000E   0001 0001 00F1   0003 001A 001A 001D';
+        assert.deepEqual(parseLookup(2, data), {
+            substFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0xf1]
+            },
+            sequences: [
+                [0x1a, 0x1a, 0x1d]
+            ]
+        });
+    });
+
+    //// Lookup type 3 ////////////////////////////////////////////////////////
+    it('can parse lookup3', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX5
+        var data = '0001 0008 0001 000E   0001 0001 003A   0002 00C9 00CA';
+        assert.deepEqual(parseLookup(3, data), {
+            substFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0x3a]
+            },
+            alternateSets: [
+                [0xc9, 0xca]
+            ]
+        });
+    });
+
+    //// Lookup type 4 ////////////////////////////////////////////////////////
+    it('can parse lookup4', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX6
+        var data = '0001 000A 0002 0014 0020' +                     // LigatureSubstFormat1
+            '0002 0001 0019 001A 0000' +                            // coverage format 2
+            '0001 0004 015B 0003 0028 0017' +                       // Ligature set "etc"
+            '0002 0006 000E 00F1 0003 001A 001D 00F0 0002 001D';    // Ligature set "ffi" and "fi"
+        assert.deepEqual(parseLookup(4, data), {
+            substFormat: 1,
+            coverage: {
+                format: 2,
+                ranges: [{ start: 0x19, end: 0x1a, index: 0 }]
+            },
+            ligatureSets: [
+                [
+                    { ligGlyph: 0x15B, components: [0x28, 0x17] }
+                ],
+                [
+                    { ligGlyph: 0xf1, components: [0x1a, 0x1d] },
+                    { ligGlyph: 0xf0, components: [0x1d] }
+                ]
+            ]
+        });
+    });
+
+    //// Lookup type 5 ////////////////////////////////////////////////////////
+    it('can parse lookup5 substFormat 1', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX7
+        var data = '0001 000A 0002 0012 0020' +                 // ContextSubstFormat1
+            '0001 0002 0028 005D' +                             // coverage format 1
+            '0001 0004 0002 0001 005D 0000 0001' +              // sub rule set "space and dash"
+            '0001 0004 0002 0001 0028 0001 0001';               // sub rule set "dash and space"
+        assert.deepEqual(parseLookup(5, data), {
+            substFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0x28, 0x5d]                                // space, dash
+            },
+            ruleSets: [
+                [{ input: [0x5d], lookupRecords: [{ sequenceIndex: 0, lookupListIndex: 1 }] }],
+                [{ input: [0x28], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }]
+            ]
+        });
+    });
+
+    it('can parse lookup5 substFormat 2', function() {
+        /* jshint elision: true */
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX8
+        var data = '0002 0010 001C 0004 0000 0000 0032 0040' +          // ContextSubstFormat2
+            '0001 0004 0030 0031 0040 0041' +                           // coverage format 1
+            '0002 0003 0030 0031 0002 0040 0041 0003 00D2 00D3 0001' +  // class def format 2
+            '0001 0004 0002 0001 0001 0001 0001' +                      // sub class set "set marks high"
+            '0001 0004 0002 0001 0001 0001 0002';                       // sub class set "set marks very high"
+        assert.deepEqual(parseLookup(5, data), {
+            substFormat: 2,
+            coverage: {
+                format: 1,
+                glyphs: [0x30, 0x31, 0x40, 0x41]
+            },
+            classDef: {
+                format: 2,
+                ranges: [
+                    { start: 0x30, end: 0x31, classId: 2 },
+                    { start: 0x40, end: 0x41, classId: 3 },
+                    { start: 0xd2, end: 0xd3, classId: 1 }
+                ]
+            },
+            classSets: [
+                undefined,
+                undefined,           // mocha.assert doesn't seem to be happy with undefined here.
+                [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 1 }] }],
+                [{ classes: [1], lookupRecords: [{ sequenceIndex: 1, lookupListIndex: 2 }] }]
+            ]
+        });
+    });
+
+    it('can parse lookup5 substFormat 3', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX9
+        // Coverage offsets (0030, 004C, 006E) seem wrong in the example.
+        // var data = '0003 0003 0002 0030 004C 006E 0000 0001 0002 0002'
+        var data = '0003 0003 0002 0014 0030 0052 0000 0001 0002 0002' +                // ContextSubstFormat3
+            '0001 000C 0033 0035 0037 0038 0039 003B 003C 003D 0041 0042 0045 004A' +   // coverage format 1
+            '0001 000F 0032 0034 0036 003A 003E 003F 0040 0043 0044 0045 0046 0047 0048 0049 004B' + // coverage format 1
+            '0001 0005 0038 003B 0041 0042 004A';                                       // coverage format 1
+        assert.deepEqual(parseLookup(5, data), {
+            substFormat: 3,
+            coverages: [{
+                    format: 1,
+                    glyphs: [0x33, 0x35, 0x37, 0x38, 0x39, 0x3b, 0x3c, 0x3d, 0x41, 0x42, 0x45, 0x4a]
+                },
+                {
+                    format: 1,
+                    glyphs: [0x32, 0x34, 0x36, 0x3a, 0x3e, 0x3f, 0x40, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4b]
+                },
+                {
+                    format: 1,
+                    glyphs: [0x38, 0x3b, 0x41, 0x42, 0x4a]
+                }],
+            lookupRecords: [
+                { sequenceIndex: 0, lookupListIndex: 1 },
+                { sequenceIndex: 2, lookupListIndex: 2 }
+            ]
+        });
+    });
+
+    //// Lookup type 6 ////////////////////////////////////////////////////////
+    // TODO (no example in the doc from Microsoft)
+
+    //// Lookup type 7 ////////////////////////////////////////////////////////
+    // TODO (no example in the doc from Microsoft)
+
+    //// Lookup type 8 ////////////////////////////////////////////////////////
+    it('can parse lookup8', function() {
+        // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX10
+        // In the Microsoft example, the third UShort (BacktrackGlyphCount) is 0000. It should be 0001
+        // since there is an offset (NULL) to BacktrackCoverage[0]
+        var data = '0001 0068 0001 0000 0001 0026 000C 00A7 00B9 00C5 00D4 00EA 00F2 00FD 010D 011B 012B 013B 0141' + // ReverseChainSingleSubstFormat1
+            '0001 001F 00A5 00A9 00AA 00E2 0167 0168 0169 016D 016E 0170 0183' +     // coverage format 1
+            '0184 0185 0189 018A 018C019F 01A0 01A1 01A2 01A3 01A4 01A5 01A6' +
+            '01A7 01A8 01A9 01AA 01AB 01AC 01EC' +
+            '0001 000C 00A6 00B7 00C3 00D2 00E9 00F1 00FC 010C 0119 0129 013A 0140'; // coverage format 1
+
+        var parsed = parseLookup(8, data);
+        assert.deepEqual(parsed, {
+            substFormat: 1,
+            coverage: {
+                format: 1,
+                glyphs: [0xa6, 0xb7, 0xc3, 0xd2, 0xe9, 0xf1, 0xfc, 0x10c, 0x119, 0x129, 0x13a, 0x140]
+            },
+            backtrackCoverage: [undefined],
+            lookaheadCoverage: [{
+                format: 1,
+                glyphs: [
+                    0xa5, 0xa9, 0xaa, 0xe2, 0x167, 0x168, 0x169, 0x16d, 0x16e, 0x170, 0x183, 0x184, 0x185,
+                    0x189, 0x18a, 0x18c, 0x19f, 0x1a0, 0x1a1, 0x1a2, 0x1a3, 0x1a4, 0x1a5, 0x1a6, 0x1a7,
+                    0x1a8, 0x1a9, 0x1aa, 0x1ab, 0x1ac, 0x1ec
+                ]
+            }],
+            substitutes: [0xa7, 0xb9, 0xc5, 0xd4, 0xea, 0xf2, 0xfd, 0x10d, 0x11b, 0x12b, 0x13b, 0x141]
+        });
+    });
+});


### PR DESCRIPTION
Full parsing of the GSUB table.
I took some inspiration from Fontkit to keep things compact and expressive.
Most of the logic is in the Parser class to make it available to other Layout tables (especially GPOS which needs refactoring).
Unit tests are taken directly from the Microsoft OTSPEC documentation examples.