### PR TITLE
GSUB table edition

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -6,6 +6,7 @@ var path = require('./path');
 var sfnt = require('./tables/sfnt');
 var encoding = require('./encoding');
 var glyphset = require('./glyphset');
+var Substitution = require('./substitution');
 var util = require('./util');
 
 // A Font represents a loaded OpenType font file.
@@ -54,6 +55,7 @@ function Font(options) {
     this.supported = true; // Deprecated: parseBuffer will throw an error if font is not supported.
     this.glyphs = new glyphset.GlyphSet(this, options.glyphs || []);
     this.encoding = new encoding.DefaultEncoding(this);
+    this.substitution = new Substitution(this);
     this.tables = this.tables || {};
 }
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,0 +1,204 @@
+// The Layout object is the prototype of Substition objects, and provides utility methods to manipulate
+// common layout tables (GPOS, GSUB, GDEF...)
+
+'use strict';
+
+function searchTag(arr, tag) {
+    /* jshint bitwise: false */
+    var imin = 0;
+    var imax = arr.length - 1;
+    while (imin <= imax) {
+        var imid = (imin + imax) >>> 1;
+        var val = arr[imid].tag;
+        if (val === tag) {
+            return imid;
+        } else if (val < tag) {
+            imin = imid + 1;
+        } else { imax = imid - 1; }
+    }
+    // Not found: return -1-insertion point
+    return -imin - 1;
+}
+
+function binSearch(arr, value) {
+    /* jshint bitwise: false */
+    var imin = 0;
+    var imax = arr.length - 1;
+    while (imin <= imax) {
+        var imid = (imin + imax) >>> 1;
+        var val = arr[imid];
+        if (val === value) {
+            return imid;
+        } else if (val < value) {
+            imin = imid + 1;
+        } else { imax = imid - 1; }
+    }
+    // Not found: return -1-insertion point
+    return -imin - 1;
+}
+
+var Layout = {
+    // Binary search an object by "tag" property
+    searchTag: searchTag,
+
+    // Binary search in a list of numbers
+    binSearch: binSearch,
+
+    // Returns all scripts in the substitution table.
+    getScriptNames: function() {
+        var gsub = this.getGsubTable();
+        if (!gsub) { return []; }
+        return gsub.scripts.map(function(script) {
+            return script.tag;
+        });
+    },
+
+    /**
+     * Returns all LangSysRecords in the given script.
+     * @param {string} script - Use 'DFLT' for default script
+     * @param {boolean} create - forces the creation of this script table if it doesn't exist.
+     */
+    getScriptTable: function(script, create) {
+        var gsub = this.getGsubTable(create);
+        if (gsub) {
+            var scripts = gsub.scripts;
+            var pos = searchTag(gsub.scripts, script);
+            if (pos >= 0) {
+                return scripts[pos].script;
+            } else {
+                var scr = {
+                    tag: script,
+                    script: {
+                        defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
+                        langSysRecords: []
+                    }
+                };
+                scripts.splice(-1 - pos, 0, scr.script);
+                return scr;
+            }
+        }
+    },
+
+    /**
+     * Returns a language system table
+     * @param {string} script - Use 'DFLT' for default script
+     * @param {string} language - Use 'DFLT' for default language
+     * @param {boolean} create - forces the creation of this langSysTable if it doesn't exist.
+     */
+    getLangSysTable: function(script, language, create) {
+        var scriptTable = this.getScriptTable(script, create);
+        if (scriptTable) {
+            if (language === 'DFLT') {
+                return scriptTable.defaultLangSys;
+            }
+            var pos = searchTag(scriptTable.langSysRecords, language);
+            if (pos >= 0) {
+                return scriptTable.langSysRecords[pos].langSys;
+            } else if (create) {
+                var langSysRecord = {
+                    tag: language,
+                    langSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] }
+                };
+                scriptTable.langSysRecords.splice(-1 - pos, 0, langSysRecord);
+                return langSysRecord.langSys;
+            }
+        }
+    },
+
+    /**
+     * Get a specific feature table.
+     *
+     * @param {string} script - Use 'DFLT' for default script
+     * @param {string} language - Use 'DFLT' for default language
+     * @param {string} feature - One of the codes listed at https://www.microsoft.com/typography/OTSPEC/featurelist.htm
+     * @param {boolean} create - forces the creation of the feature table if it doesn't exist.
+     */
+    getFeatureTable: function(script, language, feature, create) {
+        var langSysTable = this.getLangSysTable(script, language, create);
+        if (langSysTable) {
+            var featureRecord;
+            var featIndexes = langSysTable.featureIndexes;
+            var allFeatures = this.font.tables.gsub.features;
+            // The FeatureIndex array of indices is in arbitrary order,
+            // even if allFeatures is sorted alphabetically by feature tag.
+            for (var i = 0; i < featIndexes.length; i++) {
+                featureRecord = allFeatures[featIndexes[i]];
+                if (featureRecord.tag === feature) {
+                    return featureRecord.feature;
+                }
+            }
+            if (create) {
+                featureRecord = {
+                    tag: feature,
+                    feature: { params: 0, lookupListIndexes: [] }
+                };
+                var index = allFeatures.length;
+                allFeatures.push(featureRecord);
+                featIndexes.push(index);
+                return featureRecord.feature;
+            }
+        }
+    },
+
+    /**
+     * Get the first lookup table of a given type for a script/language/feature.
+     * @param {string} script - Use 'DFLT' for default script
+     * @param {string} language - Use 'DFLT' for default language
+     * @param {string} feature - 4-letter feature code
+     * @param {number} lookupType - 1 to 8
+     * @param {boolean} create - forces the creation of the lookup table if it doesn't exist, with no subtables.
+     */
+    getLookupTable: function(script, language, feature, lookupType, create) {
+        var featureTable = this.getFeatureTable(script, language, feature, create);
+        if (featureTable) {
+            var lookupTable;
+            var lookupListIndexes = featureTable.lookupListIndexes;
+            var allLookups = this.font.tables.gsub.lookups;
+            // lookupListIndexes are in no particular order, so use naïve search.
+            for (var i = 0; i < lookupListIndexes.length; i++) {
+                lookupTable = allLookups[lookupListIndexes[i]];
+                if (lookupTable.lookupType === lookupType) {
+                    return lookupTable;
+                }
+            }
+            if (create) {
+                lookupTable = {
+                    lookupType: lookupType,
+                    lookupFlag: 0,
+                    subtables: [],
+                    markFilteringSet: undefined
+                };
+                var index = allLookups.length;
+                allLookups.push(lookupTable);
+                lookupListIndexes.push(index);
+                return lookupTable;
+            }
+        }
+    },
+
+    /**
+     * Returns the list of glyph indexes of a coverage table.
+     * Format 1: the list is stored raw
+     * Format 2: compact list as range records.
+     */
+    expandCoverage: function(coverageTable) {
+        if (coverageTable.format === 1) {
+            return coverageTable.glyphs;
+        } else {
+            var glyphs = [];
+            var ranges = coverageTable.ranges;
+            for (var i = 0; i < ranges; i++) {
+                var range = ranges[i];
+                var start = range.start;
+                var end = range.end;
+                for (var j = start; j <= end; j++) {
+                    glyphs.push(j);
+                }
+            }
+            return glyphs;
+        }
+    }
+
+};
+
+module.exports = Layout;

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -1,0 +1,159 @@
+// The Substitution object provides utility methods to manipulate
+// the GSUB substitution table.
+
+'use strict';
+
+var check = require('./check');
+var Layout = require('./layout');
+
+var Substitution = function(font) {
+    this.font = font;
+};
+
+// Check if 2 arrays of primitives are equal.
+function arraysEqual(ar1, ar2) {
+    var n = ar1.length;
+    if (n !== ar2.length) { return false; }
+    for (var i = 0; i < n; i++) {
+        if (ar1[i] !== ar2[i]) { return false; }
+    }
+    return true;
+}
+
+Substitution.prototype = Layout;
+
+// Get or create the GSUB table.
+Substitution.prototype.getGsubTable = function(create) {
+    var gsub = this.font.tables.gsub;
+    if (!gsub && create) {
+        // Generate a default empty GSUB table with just a DFLT script and dflt lang sys.
+        this.font.tables.gsub = gsub = {
+            version: 1,
+            scripts: [{
+                tag: 'DFLT',
+                script: {
+                    defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
+                    langSysRecords: []
+                }
+            }],
+            features: [],
+            lookups: []
+        };
+    }
+    return gsub;
+};
+
+/**
+ * List all ligatures (lookup type 4) for a given script, language, and feature.
+ * The result is an array of ligature objects like { sub: [ids], by: id }
+ * @param {string} script
+ * @param {string} language
+ * @param {string} feature - 4-letter feature name (liga, rlig, dlig...)
+ */
+Substitution.prototype.getLigatures = function(script, language, feature) {
+    var lookupTable = this.getLookupTable(script, language, feature, 4);
+    if (!lookupTable) { return []; }
+    var subtable = lookupTable.subtables[0];
+    if (!subtable) { return []; }
+    var glyphs = this.expandCoverage(subtable.coverage);
+    var ligatureSets = subtable.ligatureSets;
+    var ligatures = [];
+    for (var i = 0; i < glyphs.length; i++) {
+        var startGlyph = glyphs[i];
+        var ligSet = ligatureSets[i];
+        for (var j = 0; j < ligSet.length; j++) {
+            var lig = ligSet[j];
+            ligatures.push({
+                sub: [startGlyph].concat(lig.components),
+                by: lig.ligGlyph
+            });
+        }
+    }
+    return ligatures;
+};
+
+/**
+ * Add a ligature (lookup type 4)
+ * Ligatures with more components must be stored ahead of those with fewer components in order to be found
+ * @param {string} [script='DFLT']
+ * @param {string} [language='DFLT']
+ * @param {object} ligature - { sub: [ids], by: id }
+ */
+Substitution.prototype.addLigature = function(script, language, feature, ligature) {
+    var lookupTable = this.getLookupTable(script, language, feature, 4, true);
+    var subtable = lookupTable.subtables[0];
+    if (!subtable) {
+        subtable = {                // lookup type 4 subtable, format 1, coverage format 1
+            substFormat: 1,
+            coverage: { format: 1, glyphs: [] },
+            ligatureSets: []
+        };
+        lookupTable.subtables[0] = subtable;
+    }
+    check.assert(subtable.coverage.format === 1, 'Ligature: unable to modify coverage table format ' + subtable.coverage.format);
+    var coverageGlyph = ligature.sub[0];
+    var ligComponents = ligature.sub.slice(1);
+    var ligatureTable = {
+        ligGlyph: ligature.by,
+        components: ligComponents
+    };
+    var pos = this.binSearch(subtable.coverage.glyphs, coverageGlyph);
+    if (pos >= 0) {
+        // ligatureSet already exists
+        var ligatureSet = subtable.ligatureSets[pos];
+        for (var i = 0; i < ligatureSet.length; i++) {
+            // If ligature already exists, return.
+            if (arraysEqual(ligatureSet[i].components, ligComponents)) {
+                return;
+            }
+        }
+        // ligature does not exist: add it.
+        ligatureSet.push(ligatureTable);
+    } else {
+        // Create a new ligatureSet and add coverage for the first glyph.
+        pos = -1 - pos;
+        subtable.coverage.glyphs.splice(pos, 0, coverageGlyph);
+        subtable.ligatureSets.splice(pos, 0, [ligatureTable]);
+    }
+};
+
+/**
+ * List all feature data for a given script and language.
+ * @param {string} [script='DFLT']
+ * @param {string} [language='DFLT']
+ * @param {string} feature - 4-letter feature name
+ */
+Substitution.prototype.getFeature = function(script, language, feature) {
+    if (arguments.length === 1) {
+        feature = arguments[0];
+        script = language = 'DFLT';
+    }
+    switch (feature) {
+        case 'dlig':
+        case 'liga':
+        case 'rlig': return this.getLigatures(script, language, feature);
+    }
+};
+
+/**
+ * Add a substitution to a feature for a given script and language.
+ * The result is an array of ligature objects like { sub: [ids], by: id }
+ * @param {string} [script='DFLT']
+ * @param {string} [language='DFLT']
+ * @param {string} feature - 4-letter feature name
+ * @param {object} sub - the substitution to add
+ */
+Substitution.prototype.add = function(script, language, feature, sub) {
+    if (arguments.length === 2) {
+        feature = arguments[0];
+        sub = arguments[1];
+        script = language = 'DFLT';
+    }
+    switch (feature) {
+        case 'dlig':
+        case 'liga':
+        case 'rlig': return this.addLigature(script, language, feature, sub);
+    }
+};
+
+module.exports = Substitution;

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -1,0 +1,92 @@
+/* jshint mocha: true */
+
+'use strict';
+
+var assert = require('assert');
+var opentype = require('../src/opentype.js');
+var Substitution = require('../src/substitution.js');
+
+describe('substitution.js', function() {
+
+    var font;
+    var substitution;
+    var notdefGlyph = new opentype.Glyph({
+        name: '.notdef',
+        unicode: 0,
+        path: new opentype.Path()
+    });
+
+    var glyphs = [notdefGlyph].concat('abcdefghijklmnopqrstuvwxyz'.split('').map(function(c) {
+        return new opentype.Glyph({
+            name: c,
+            unicode: c.charCodeAt(0),
+            path: new opentype.Path()
+        });
+    }));
+
+    beforeEach(function() {
+        font = new opentype.Font({
+            familyName: 'MyFont',
+            styleName: 'Medium',
+            unitsPerEm: 1000,
+            ascender: 800,
+            descender: -200,
+            glyphs: glyphs
+        });
+        substitution = new Substitution(font);
+    });
+
+    describe('getGsubTable', function() {
+        it('must not create an empty default GSUB table', function() {
+            assert.equal(substitution.getGsubTable(), undefined);
+            assert.equal(substitution.getGsubTable(false), undefined);
+        });
+
+        it('can create an empty default GSUB table', function() {
+            assert.deepEqual(substitution.getGsubTable(true), {
+                version: 1,
+                scripts: [{
+                    tag: 'DFLT',
+                    script: {
+                        defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
+                        langSysRecords: []
+                    }
+                }],
+                features: [],
+                lookups: []
+            });
+        });
+    });
+
+    describe('add', function() {
+        it('can add ligatures (lookup type 4)', function() {
+            substitution.add('liga', { sub: [4, 5], by: 17 });
+            substitution.add('liga', { sub: [4, 6], by: 18 });
+            substitution.add('liga', { sub: [8, 1, 2], by: 19 });
+            assert.deepEqual(font.tables.gsub.scripts, [{
+                tag: 'DFLT',
+                script: {
+                    defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0] },
+                    langSysRecords: []
+                }
+            }]);
+            assert.deepEqual(font.tables.gsub.features, [{
+                tag: 'liga',
+                feature: { params: 0, lookupListIndexes: [0] }
+            }]);
+            assert.deepEqual(font.tables.gsub.lookups, [{
+                lookupFlag: 0,
+                lookupType: 4,
+                markFilteringSet: undefined,
+                subtables: [{
+                    substFormat: 1,
+                    coverage: { format: 1, glyphs: [4, 8] },
+                    ligatureSets: [
+                        [{ ligGlyph: 17, components: [5] }, { ligGlyph: 18, components: [6] }],
+                        [{ ligGlyph: 19, components: [1, 2] }]
+                    ]
+                }]
+            }]);
+        });
+    });
+});


### PR DESCRIPTION
As discussed in #194, this is the beginning of an API to edit the data in in the `font.tables.gsub` object.
`font.substitution.getFeature()` returns a list of entries in lookup 4 (ligature) tables.
`font.substitution.add()` can add entries in lookup 4 tables.
More lookup types can be added.