### PR TITLE
(limited) GSUB writing

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var check = require('./check');
 var encode = require('./types').encode;
 var sizeOf = require('./types').sizeOf;
 
@@ -34,4 +35,88 @@ Table.prototype.sizeOf = function() {
     return sizeOf.TABLE(this);
 };
 
+function ushortList(itemName, list, count) {
+    if (count === undefined) {
+        count = list.length;
+    }
+    var fields = new Array(list.length + 1);
+    fields[0] = {name: itemName + 'Count', type: 'USHORT', value: count};
+    for (var i = 0; i < list.length; i++) {
+        fields[i + 1] = {name: itemName + i, type: 'USHORT', value: list[i]};
+    }
+    return fields;
+}
+
+function tableList(itemName, records, itemCallback) {
+    var count = records.length;
+    var fields = new Array(count + 1);
+    fields[0] = {name: itemName + 'Count', type: 'USHORT', value: count};
+    for (var i = 0; i < count; i++) {
+        fields[i + 1] = {name: itemName + i, type: 'TABLE', value: itemCallback(records[i], i)};
+    }
+    return fields;
+}
+
+function recordList(itemName, records, itemCallback) {
+    var count = records.length;
+    var fields = [];
+    fields[0] = {name: itemName + 'Count', type: 'USHORT', value: count};
+    for (var i = 0; i < count; i++) {
+        fields = fields.concat(itemCallback(records[i], i));
+    }
+    return fields;
+}
+
+// Common Layout Tables
+function Coverage(coverageTable) {
+    if (coverageTable.format === 1) {
+        Table.call(this, 'coverageTable',
+            [{name: 'coverageFormat', type: 'USHORT', value: 1}]
+            .concat(ushortList('glyph', coverageTable.glyphs))
+        );
+    } else {
+        check.assert(false, 'Can\'t create coverage table format 2 yet.');
+    }
+}
+Coverage.prototype = Object.create(Table.prototype);
+Coverage.prototype.constructor = Coverage;
+
+// Missing: script list. See gsub.js
+
+function FeatureList(featureListTable) {
+    Table.call(this, 'featureListTable',
+        recordList('featureRecord', featureListTable, function(featureRecord, i) {
+            var feature = featureRecord.feature;
+            return [
+                {name: 'featureTag' + i, type: 'TAG', value: featureRecord.tag},
+                {name: 'feature' + i, type: 'TABLE', value: new Table('featureTable', [
+                    {name: 'featureParams', type: 'USHORT', value: feature.featureParams},
+                    ].concat(ushortList('lookupListIndex', feature.lookupListIndexes)))}
+            ];
+        })
+    );
+}
+FeatureList.prototype = Object.create(Table.prototype);
+FeatureList.prototype.constructor = FeatureList;
+
+function LookupList(lookupListTable, subtableMakers) {
+    Table.call(this, 'lookupListTable', tableList('lookup', lookupListTable, function(lookupTable) {
+        return new Table('lookupTable', [
+            {name: 'lookupType', type: 'USHORT', value: lookupTable.lookupType},
+            {name: 'lookupFlag', type: 'USHORT', value: lookupTable.lookupFlag}
+        ].concat(tableList('subtable', lookupTable.subtables, subtableMakers[lookupTable.lookupType])));
+    }));
+}
+LookupList.prototype = Object.create(Table.prototype);
+LookupList.prototype.constructor = LookupList;
+
+// Record = same as Table, but inlined (a Table has an offset and its data is further in the stream)
+// Don't use offsets inside Records (probable bug), only in Tables.
 exports.Record = exports.Table = Table;
+exports.Coverage = Coverage;
+exports.FeatureList = FeatureList;
+exports.LookupList = LookupList;
+
+exports.ushortList = ushortList;
+exports.tableList = tableList;
+exports.recordList = recordList;

--- a/src/tables/sfnt.js
+++ b/src/tables/sfnt.js
@@ -19,6 +19,7 @@ var maxp = require('./maxp');
 var _name = require('./name');
 var os2 = require('./os2');
 var post = require('./post');
+var gsub = require('./gsub');
 
 function log2(v) {
     return Math.log(v) / Math.log(2) | 0;
@@ -302,6 +303,10 @@ function fontToSfntTable(font) {
     var tables = [headTable, hheaTable, maxpTable, os2Table, nameTable, cmapTable, postTable, cffTable, hmtxTable];
     if (ltagTable) {
         tables.push(ltagTable);
+    }
+    // Optional tables
+    if (font.tables.gsub) {
+        tables.push(gsub.make(font.tables.gsub));
     }
 
     var sfntTable = makeSfntTable(tables);

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,8 +3,8 @@
 'use strict';
 
 var assert = require('assert');
-var testutil = require('./testutil.js');
-var Parser = require('../src/parse.js').Parser;
+var testutil = require('./testutil');
+var Parser = require('../src/parse').Parser;
 
 describe('parse.js', function() {
 

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -3,8 +3,8 @@
 'use strict';
 
 var assert = require('assert');
-var opentype = require('../src/opentype.js');
-var Substitution = require('../src/substitution.js');
+var opentype = require('../src/opentype');
+var Substitution = require('../src/substitution');
 
 describe('substitution.js', function() {
 

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -3,8 +3,8 @@
 'use strict';
 
 var assert = require('assert');
-var testutil = require('../testutil.js');
-var gsub = require('../../src/tables/gsub.js');
+var testutil = require('../testutil');
+var gsub = require('../../src/tables/gsub');
 
 // Helper that builds a minimal GSUB table to test a lookup subtable.
 function parseLookup(lookupType, subTableData) {

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -232,7 +232,7 @@ describe('tables/gsub.js', function() {
     });
 
     /// Writing ///////////////////////////////////////////////////////////////
-    it.only('should write a simple GSUB table', function() {
+    it('should write a simple GSUB table', function() {
         var expectedData = Array.prototype.slice.call(new Uint8Array(testutil.unhex(
             '00 01 00 00 00 0A 00 1E  00 2C 00 01 44 46 4C 54  00 08 00 04 00 00 00 00  FF FF 00 01 00 00 00 01' +
             '6C 69 67 61 00 08 00 00  00 01 00 00 00 01 00 04  00 04 00 00 00 01 00 08  00 01 00 0A 00 02 00 12' +

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -230,4 +230,45 @@ describe('tables/gsub.js', function() {
             substitutes: [0xa7, 0xb9, 0xc5, 0xd4, 0xea, 0xf2, 0xfd, 0x10d, 0x11b, 0x12b, 0x13b, 0x141]
         });
     });
+
+    /// Writing ///////////////////////////////////////////////////////////////
+    it.only('should write a simple GSUB table', function() {
+        var expectedData = Array.prototype.slice.call(new Uint8Array(testutil.unhex(
+            '00 01 00 00 00 0A 00 1E  00 2C 00 01 44 46 4C 54  00 08 00 04 00 00 00 00  FF FF 00 01 00 00 00 01' +
+            '6C 69 67 61 00 08 00 00  00 01 00 00 00 01 00 04  00 04 00 00 00 01 00 08  00 01 00 0A 00 02 00 12' +
+            '00 2E 00 01 00 02 00 18  00 1A 00 03 00 08 00 10  00 16 04 8A 00 03 00 34  00 34 04 84 00 02 00 18' +
+            '04 83 00 02 00 34 00 01  00 04 04 8D 00 02 00 1D'
+        ).buffer));
+
+        var gsubTable = {
+            version: 1,
+            scripts: [{
+                tag: 'DFLT',
+                script: {
+                    defaultLangSys: { reserved: 0, reqFeatureIndex: 65535, featureIndexes: [0] },
+                    langSysRecords: []
+                }
+            }],
+            features: [{ tag: 'liga', feature: { featureParams: 0, lookupListIndexes: [0] } }],
+            lookups: [{
+                lookupType: 4,
+                lookupFlag: 0,
+                subtables: [{
+                    substFormat: 1,
+                    coverage: { format: 1, glyphs: [24, 26] },
+                    ligatureSets: [
+                        [
+                            {ligGlyph: 1162, components: [52, 52]},
+                            {ligGlyph: 1156, components: [24]},
+                            {ligGlyph: 1155, components: [52]}
+                        ],
+                        [
+                            {ligGlyph: 1165, components: [29]}
+                        ]
+                    ]
+                }]
+            }]
+        };
+        assert.deepEqual(gsub.make(gsubTable).encode(), expectedData);
+    });
 });


### PR DESCRIPTION
Adds simple GSUB writing capabilities.
- Common Layout Tables writing is exposed in `table.js` to be reused with other tables (mostly)
- Only lookup type 1 format 1 (single substitution) and lookup type 4 (ligature)
- Only Coverage format 1 (individual glyphs)
- Only DFLT script and defaultLangSys
