### PR TITLE
No glyph names fix

### DIFF
--- a/src/encoding.js
+++ b/src/encoding.js
@@ -218,7 +218,7 @@ function addGlyphNames(font) {
         glyph = font.glyphs.get(i);
         if (font.cffEncoding) {
             glyph.name = font.cffEncoding.charset[i];
-        } else {
+        } else if (font.glyphNames.names) {
             glyph.name = font.glyphNames.glyphIndexToName(i);
         }
     }


### PR DESCRIPTION
If a font file doesn't have font.glyphNames.names then function
addGlyphNames(font) throws an error "TypeError: Cannot read property '0'
of undefined"