### PR TITLE
Support glyf table component offset by matched points

### DIFF
--- a/glyph-inspector.html
+++ b/glyph-inspector.html
@@ -151,7 +151,11 @@ function displayGlyphData(glyphIndex) {
     } else if (glyph.isComposite) {
         html += '<br>This composite glyph is a combination of :<ul><li>' +
             glyph.components.map(function(component) {
-                return 'glyph '+component.glyphIndex+' at dx='+component.dx+', dy='+component.dy;
+                if (component.matchedPoints === undefined) {
+                    return 'glyph '+component.glyphIndex+' at dx='+component.dx+', dy='+component.dy;
+                } else {
+                    return 'glyph '+component.glyphIndex+' at matchedPoints=['+component.matchedPoints+']';
+                }
             }).join('</li><li>') + '</li></ul>';
     } else if (glyph.path) {
         html += 'path:<br><pre>  ' + glyph.path.commands.map(pathCommandToString).join('\n  ') + '\n</pre>';

--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -289,6 +289,10 @@ function buildPath(glyphs, glyph) {
                     transformedPoints = transformPoints(componentGlyph.points, component);
                 } else {
                     // component positioned by matched points
+                    if ((component.matchedPoints[0] > glyph.points.length - 1) ||
+                        (component.matchedPoints[1] > componentGlyph.points.length - 1)) {
+                        throw Error('Matched points out of range in ' + glyph.name);
+                    }
                     var firstPt = glyph.points[component.matchedPoints[0]];
                     var secondPt = componentGlyph.points[component.matchedPoints[1]];
                     var transform = {


### PR DESCRIPTION
See https://www.microsoft.com/typography/otspec/glyf.htm
> Argument1 and argument2 can be either x and y offsets to be added to the glyph or two point numbers. In the latter case, the first point number indicates the point that is to be matched to the new glyph. The second number indicates the new glyph's “matched” point. Once a glyph is added, its point numbers begin directly after the last glyphs (endpoint of first glyph + 1).