### PR TITLE
Take optional filename argument in download

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -398,10 +398,10 @@ Font.prototype.toArrayBuffer = function() {
 /**
  * Initiate a download of the OpenType font.
  */
-Font.prototype.download = function() {
+Font.prototype.download = function(fileName) {
     var familyName = this.getEnglishName('fontFamily');
     var styleName = this.getEnglishName('fontSubfamily');
-    var fileName = familyName.replace(/\s/g, '') + '-' + styleName + '.otf';
+    fileName = fileName || familyName.replace(/\s/g, '') + '-' + styleName + '.otf';
     var arrayBuffer = this.toArrayBuffer();
 
     if (util.isBrowser()) {


### PR DESCRIPTION
To redefine path where font is generated, for example, `font/fontName.otf` to place font to a directory