### PR TITLE
Fixes error that occurs when subtable is not returned

### DIFF
--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -193,7 +193,9 @@ function parseLookupTable(data, start) {
     if (lookupType === 2) {
         var subtables = [];
         for (var i = 0; i < subTableCount; i++) {
-            subtables.push(parsePairPosSubTable(data, start + subTableOffsets[i]));
+            var subtable = parsePairPosSubTable(data, start + subTableOffsets[i]);
+            if (subtable == null) continue;
+            subtables.push(subtable);
         }
         // Return a function which finds the kerning values in the subtables.
         table.getKerningValue = function(leftGlyph, rightGlyph) {


### PR DESCRIPTION
I noticed this issue when using the Cardo font: https://fonts.google.com/specimen/Cardo
