### PR TITLE
Convert the path to a SVG <path> element as a html element

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -246,4 +246,13 @@ Path.prototype.toSVG = function(decimalPlaces) {
     return svg;
 };
 
+Path.prototype.toHTML = function(decimalPlaces) {
+  var temporaryPath = this.toPathData(decimalPlaces);
+  var newPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+  newPath.setAttribute('d', temporaryPath);
+
+  return newPath;
+};
+
 exports.Path = Path;

--- a/src/path.js
+++ b/src/path.js
@@ -246,13 +246,13 @@ Path.prototype.toSVG = function(decimalPlaces) {
     return svg;
 };
 
-Path.prototype.toHTML = function(decimalPlaces) {
-  var temporaryPath = this.toPathData(decimalPlaces);
-  var newPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+Path.prototype.toDOMElement = function(decimalPlaces) {
+    var temporaryPath = this.toPathData(decimalPlaces);
+    var newPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
-  newPath.setAttribute('d', temporaryPath);
+    newPath.setAttribute('d', temporaryPath);
 
-  return newPath;
+    return newPath;
 };
 
 exports.Path = Path;


### PR DESCRIPTION
I added a function, that returns an svg path as an html element, so you can add your newly rendered path straight into specific DOM element, without struggling with string parsing.

[Codepen Demo here.](http://codepen.io/jakub_antolak/pen/zNYMeK)