### PR TITLE
Add ligature rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Create a Path that represents the given text.
 
 Options is an optional object containing:
 * `kerning`: if true takes kerning information into account (default: true)
+* `features`: an object with [OpenType feature tags](https://www.microsoft.com/typography/otspec/featuretags.htm) as keys, and a boolean value to enable each feature.
+Currently only ligature features "liga" and "rlig" are supported (default: true).
 
 _Note: there is also `Font.getPaths` with the same arguments which returns a list of Paths._
 
@@ -252,7 +254,7 @@ Convert the path to a SVG &lt;path&gt; element, as a string.
 
 Planned
 =======
-* Support for ligatures and contextual alternates.
+* Support for contextual alternates.
 
 Thanks
 ======

--- a/externs/opentype.js
+++ b/externs/opentype.js
@@ -348,7 +348,7 @@ opentype.Path.prototype.toSVG = function(decimalPlaces) {};
 /**
  * @constructor
  */
-opentype.Layout = function() {};
+opentype.Layout = function(font, tableName) {};
 
 /**
  * Binary search an object by "tag" property
@@ -365,6 +365,13 @@ opentype.Layout.prototype.searchTag = function(arr, tag) {};
  * @return {number}
  */
 opentype.Layout.prototype.binSearch = function (arr, value) {};
+
+/**
+ * Get or create the Layout table (GSUB, GPOS etc).
+ * @param  {boolean} create - Whether to create a new one.
+ * @return {Object} The GSUB or GPOS table.
+ */
+opentype.Layout.prototype.getTable = function(create) {};
 
 /**
  * Returns all scripts in the substitution table.
@@ -386,7 +393,7 @@ opentype.Layout.prototype.getScriptTable = function(script, create) {};
  * Returns a language system table
  * @instance
  * @param {string} script - Use 'DFLT' for default script
- * @param {string} language - Use 'DFLT' for default language
+ * @param {string} language - Use 'dlft' for default language
  * @param {boolean} create - forces the creation of this langSysTable if it doesn't exist.
  * @return {Object} An object with tag and script properties.
  */
@@ -396,7 +403,7 @@ opentype.Layout.prototype.getLangSysTable = function(script, language, create) {
  * Get a specific feature table.
  * @instance
  * @param {string} script - Use 'DFLT' for default script
- * @param {string} language - Use 'DFLT' for default language
+ * @param {string} language - Use 'dlft' for default language
  * @param {string} feature - One of the codes listed at https://www.microsoft.com/typography/OTSPEC/featurelist.htm
  * @param {boolean} create - forces the creation of the feature table if it doesn't exist.
  * @return {Object}
@@ -404,16 +411,16 @@ opentype.Layout.prototype.getLangSysTable = function(script, language, create) {
 opentype.Layout.prototype.getFeatureTable = function(script, language, feature, create) {};
 
 /**
- * Get the first lookup table of a given type for a script/language/feature.
+ * Get the lookup tables of a given type for a script/language/feature.
  * @instance
- * @param {string} script - Use 'DFLT' for default script
- * @param {string} language - Use 'DFLT' for default language
+ * @param {string} [script='DFLT']
+ * @param {string} [language='dlft']
  * @param {string} feature - 4-letter feature code
  * @param {number} lookupType - 1 to 8
  * @param {boolean} create - forces the creation of the lookup table if it doesn't exist, with no subtables.
- * @return {Object}
+ * @return {Object[]}
  */
-opentype.Layout.prototype.getLookupTable = function(script, language, feature, lookupType, create) {};
+opentype.Layout.prototype.getLookupTables = function(script, language, feature, lookupType, create) {};
 
 /**
  * Returns the list of glyph indexes of a coverage table.
@@ -433,11 +440,10 @@ opentype.Layout.prototype.expandCoverage = function(coverageTable) {};
 opentype.Substitution = function(font) {};
 
 /**
- * Get or create the GSUB table.
- * @param  {Boolean} create
- * @return {Object}
+ * Create a default GSUB table.
+ * @return {Object} gsub - The GSUB table.
  */
-opentype.Substitution.prototype.getGsubTable = function(create) {};
+Substitution.prototype.createDefaultTable = function() {};
 
 /**
  * List all single substitutions (lookup type 1) for a given script, language, and feature.
@@ -473,7 +479,7 @@ opentype.Substitution.prototype.getLigatures = function(feature, script, languag
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} substitution - { sub: id, delta: number } for format 1 or { sub: id, by: id } for format 2.
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 opentype.Substitution.prototype.addSingle = function(feature, substitution, script, language) {};
 
@@ -482,7 +488,7 @@ opentype.Substitution.prototype.addSingle = function(feature, substitution, scri
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} substitution - { sub: id, by: [ids] }
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 opentype.Substitution.prototype.addAlternate = function(feature, substitution, script, language) {};
 
@@ -492,7 +498,7 @@ opentype.Substitution.prototype.addAlternate = function(feature, substitution, s
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} ligature - { sub: [ids], by: id }
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 opentype.Substitution.prototype.addLigature = function(feature, ligature, script, language) {};
 
@@ -500,7 +506,7 @@ opentype.Substitution.prototype.addLigature = function(feature, ligature, script
  * List all feature data for a given script and language.
  * @param {string} feature - 4-letter feature name
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  * @return {[type]} [description]
  * @return {Array} substitutions - The list of substitutions.
  */
@@ -511,7 +517,7 @@ opentype.Substitution.prototype.getFeature = function(feature, script, language)
  * @param {string} feature - 4-letter feature name
  * @param {Object} sub - the substitution to add (an Object like { sub: id or [ids], by: id or [ids] })
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 opentype.Substitution.prototype.add = function(feature, sub, script, language) {};
 

--- a/glyph-inspector.html
+++ b/glyph-inspector.html
@@ -129,13 +129,13 @@ function displayGlyphData(glyphIndex) {
         return;
     }
     var glyph = font.glyphs.get(glyphIndex),
-        html;
-    html = '<dt>name</dt><dd>'+glyph.name+'</dd>';
+        html = '<dl>';
+    html += '<dt>name</dt><dd>'+glyph.name+'</dd>';
 
     if (glyph.unicodes.length > 0) {
         html += '<dt>unicode</dt><dd>'+ glyph.unicodes.map(formatUnicode).join(', ') +'</dd>';
     }
-    html += '<dl><dt>index</dt><dd>'+glyph.index+'</dd>';
+    html += '<dt>index</dt><dd>'+glyph.index+'</dd>';
 
     if (glyph.xMin !== 0 || glyph.xMax !== 0 || glyph.yMin !== 0 || glyph.yMax !== 0) {
         html += '<dt>xMin</dt><dd>'+glyph.xMin+'</dd>' +
@@ -150,7 +150,7 @@ function displayGlyphData(glyphIndex) {
     html += '</dl>';
     if (glyph.numberOfContours > 0) {
         var contours = glyph.getContours();
-        html += 'contours:<br>' + contours.map(contourToString).join('\n');
+        html += 'contours:<div id="glyph-contours">' + contours.map(contourToString).join('\n') + '</div>';
     } else if (glyph.isComposite) {
         html += '<br>This composite glyph is a combination of :<ul><li>' +
             glyph.components.map(function(component) {

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
     <label><input type="checkbox" onchange="drawPointsChanged(this)" checked="checked">Draw Points</label>
     <label><input type="checkbox" onchange="drawMetricsChanged(this)">Draw Metrics</label>
     <label><input type="checkbox" onchange="kerningChanged(this)" checked="checked">Kerning</label>
+    <label><input type="checkbox" onchange="ligaturesChanged(this)" checked="checked">Ligatures</label>
 
     <hr>
 
@@ -84,6 +85,7 @@ var textToRender = "Hello, World!";
 var drawPoints = true;
 var drawMetrics = false;
 var kerning = true;
+var ligatures = true;
 var previewPath = null;
 var snapPath = null;
 var snapStrength = 80;
@@ -104,6 +106,11 @@ function drawMetricsChanged(e) {
 
 function kerningChanged(e) {
     kerning = e.checked;
+    renderText();
+}
+
+function ligaturesChanged(e) {
+    ligatures = e.checked;
     renderText();
 }
 
@@ -166,16 +173,23 @@ function renderText() {
     if (!font) return;
     textToRender = document.getElementById('textField').value;
     var previewCtx = document.getElementById('preview').getContext('2d');
+    var options = {
+        kerning: kerning,
+        features: {
+            liga: ligatures,
+            rlig: ligatures
+        }
+    };
     previewCtx.clearRect(0, 0, 940, 300);
-    font.draw(previewCtx, textToRender, 0, 200, fontSize, {kerning: kerning});
+    font.draw(previewCtx, textToRender, 0, 200, fontSize, options);
     if (drawPoints) {
-        font.drawPoints(previewCtx, textToRender, 0, 200, fontSize, {kerning: kerning});
+        font.drawPoints(previewCtx, textToRender, 0, 200, fontSize, options);
     }
     if (drawMetrics) {
-        font.drawMetrics(previewCtx, textToRender, 0, 200, fontSize, {kerning: kerning});
+        font.drawMetrics(previewCtx, textToRender, 0, 200, fontSize, options);
     }
 
-    snapPath = font.getPath(textToRender, 0, 200, fontSize, {kerning: kerning});
+    snapPath = font.getPath(textToRender, 0, 200, fontSize, options);
     doSnap(snapPath);
     var snapCtx = document.getElementById('snap').getContext('2d');
     snapCtx.clearRect(0, 0, 940, 300);

--- a/site.css
+++ b/site.css
@@ -266,10 +266,21 @@ canvas.item:hover {
     left: 0;
 }
 
-#glyph-data { float: left; margin-left: 2em; }
+#glyph-data {
+    float: left;
+    margin-left: 2em;
+    display: flex;
+    flex-flow: column nowrap;
+    height: 500px;
+}
 #glyph-data dl { margin: 0; }
 #glyph-data dt { float: left; }
 #glyph-data dd { margin-left: 12em; }
+
+#glyph-contours {
+    flex: 1 1 0;
+    overflow: auto;
+}
 
 #glyph-data pre { font-size: 11px; }
 pre:not(.contour) { margin: 0; }

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -14,7 +14,7 @@ var Layout = require('./layout');
  * @constructor
  */
 var Substitution = function(font) {
-    this.font = font;
+    Layout.call(this, font, 'gsub');
 };
 
 // Check if 2 arrays of primitives are equal.
@@ -42,59 +42,55 @@ function getSubstFormat(lookupTable, format, defaultSubtable) {
     }
 }
 
-Substitution.prototype = Layout;
+Substitution.prototype = Layout.prototype;
 
 /**
- * Get or create the GSUB table.
- * @param  {boolean} create - Whether to create a new one.
+ * Create a default GSUB table.
  * @return {Object} gsub - The GSUB table.
  */
-Substitution.prototype.getGsubTable = function(create) {
-    var gsub = this.font.tables.gsub;
-    if (!gsub && create) {
-        // Generate a default empty GSUB table with just a DFLT script and dflt lang sys.
-        this.font.tables.gsub = gsub = {
-            version: 1,
-            scripts: [{
-                tag: 'DFLT',
-                script: {
-                    defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
-                    langSysRecords: []
-                }
-            }],
-            features: [],
-            lookups: []
-        };
-    }
-    return gsub;
+Substitution.prototype.createDefaultTable = function() {
+    // Generate a default empty GSUB table with just a DFLT script and dflt lang sys.
+    return {
+        version: 1,
+        scripts: [{
+            tag: 'DFLT',
+            script: {
+                defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
+                langSysRecords: []
+            }
+        }],
+        features: [],
+        lookups: []
+    };
 };
 
 /**
  * List all single substitutions (lookup type 1) for a given script, language, and feature.
- * @param {string} script
- * @param {string} language
+ * @param {string} [script='DFLT']
+ * @param {string} [language='dflt']
  * @param {string} feature - 4-character feature name ('aalt', 'salt', 'ss01'...)
  * @return {Array} substitutions - The list of substitutions.
  */
 Substitution.prototype.getSingle = function(feature, script, language) {
     var substitutions = [];
-    var lookupTable = this.getLookupTable(script, language, feature, 1);
-    if (!lookupTable) { return substitutions; }
-    var subtables = lookupTable.subtables;
-    for (var i = 0; i < subtables.length; i++) {
-        var subtable = subtables[i];
-        var glyphs = this.expandCoverage(subtable.coverage);
-        var j;
-        if (subtable.substFormat === 1) {
-            var delta = subtable.deltaGlyphId;
-            for (j = 0; j < glyphs.length; j++) {
-                var glyph = glyphs[j];
-                substitutions.push({ sub: glyph, by: glyph + delta });
-            }
-        } else {
-            var substitute = subtable.substitute;
-            for (j = 0; j < glyphs.length; j++) {
-                substitutions.push({ sub: glyphs[j], by: substitute[j] });
+    var lookupTables = this.getLookupTables(script, language, feature, 1);
+    for (var idx = 0; idx < lookupTables.length; idx++) {
+        var subtables = lookupTables[idx].subtables;
+        for (var i = 0; i < subtables.length; i++) {
+            var subtable = subtables[i];
+            var glyphs = this.expandCoverage(subtable.coverage);
+            var j;
+            if (subtable.substFormat === 1) {
+                var delta = subtable.deltaGlyphId;
+                for (j = 0; j < glyphs.length; j++) {
+                    var glyph = glyphs[j];
+                    substitutions.push({ sub: glyph, by: glyph + delta });
+                }
+            } else {
+                var substitute = subtable.substitute;
+                for (j = 0; j < glyphs.length; j++) {
+                    substitutions.push({ sub: glyphs[j], by: substitute[j] });
+                }
             }
         }
     }
@@ -103,22 +99,23 @@ Substitution.prototype.getSingle = function(feature, script, language) {
 
 /**
  * List all alternates (lookup type 3) for a given script, language, and feature.
- * @param {string} script
- * @param {string} language
+ * @param {string} [script='DFLT']
+ * @param {string} [language='dflt']
  * @param {string} feature - 4-character feature name ('aalt', 'salt'...)
  * @return {Array} alternates - The list of alternates
  */
 Substitution.prototype.getAlternates = function(feature, script, language) {
     var alternates = [];
-    var lookupTable = this.getLookupTable(script, language, feature, 3);
-    if (!lookupTable) { return alternates; }
-    var subtables = lookupTable.subtables;
-    for (var i = 0; i < subtables.length; i++) {
-        var subtable = subtables[i];
-        var glyphs = this.expandCoverage(subtable.coverage);
-        var alternateSets = subtable.alternateSets;
-        for (var j = 0; j < glyphs.length; j++) {
-            alternates.push({ sub: glyphs[j], by: alternateSets[j] });
+    var lookupTables = this.getLookupTables(script, language, feature, 3);
+    for (var idx = 0; idx < lookupTables.length; idx++) {
+        var subtables = lookupTables[idx].subtables;
+        for (var i = 0; i < subtables.length; i++) {
+            var subtable = subtables[i];
+            var glyphs = this.expandCoverage(subtable.coverage);
+            var alternateSets = subtable.alternateSets;
+            for (var j = 0; j < glyphs.length; j++) {
+                alternates.push({ sub: glyphs[j], by: alternateSets[j] });
+            }
         }
     }
     return alternates;
@@ -128,28 +125,29 @@ Substitution.prototype.getAlternates = function(feature, script, language) {
  * List all ligatures (lookup type 4) for a given script, language, and feature.
  * The result is an array of ligature objects like { sub: [ids], by: id }
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
- * @param {string} script
- * @param {string} language
+ * @param {string} [script='DFLT']
+ * @param {string} [language='dflt']
  * @return {Array} ligatures - The list of ligatures.
  */
 Substitution.prototype.getLigatures = function(feature, script, language) {
     var ligatures = [];
-    var lookupTable = this.getLookupTable(script, language, feature, 4);
-    if (!lookupTable) { return []; }
-    var subtables = lookupTable.subtables;
-    for (var i = 0; i < subtables.length; i++) {
-        var subtable = subtables[i];
-        var glyphs = this.expandCoverage(subtable.coverage);
-        var ligatureSets = subtable.ligatureSets;
-        for (var j = 0; j < glyphs.length; j++) {
-            var startGlyph = glyphs[j];
-            var ligSet = ligatureSets[j];
-            for (var k = 0; k < ligSet.length; k++) {
-                var lig = ligSet[k];
-                ligatures.push({
-                    sub: [startGlyph].concat(lig.components),
-                    by: lig.ligGlyph
-                });
+    var lookupTables = this.getLookupTables(script, language, feature, 4);
+    for (var idx = 0; idx < lookupTables.length; idx++) {
+        var subtables = lookupTables[idx].subtables;
+        for (var i = 0; i < subtables.length; i++) {
+            var subtable = subtables[i];
+            var glyphs = this.expandCoverage(subtable.coverage);
+            var ligatureSets = subtable.ligatureSets;
+            for (var j = 0; j < glyphs.length; j++) {
+                var startGlyph = glyphs[j];
+                var ligSet = ligatureSets[j];
+                for (var k = 0; k < ligSet.length; k++) {
+                    var lig = ligSet[k];
+                    ligatures.push({
+                        sub: [startGlyph].concat(lig.components),
+                        by: lig.ligGlyph
+                    });
+                }
             }
         }
     }
@@ -162,10 +160,10 @@ Substitution.prototype.getLigatures = function(feature, script, language) {
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} substitution - { sub: id, delta: number } for format 1 or { sub: id, by: id } for format 2.
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 Substitution.prototype.addSingle = function(feature, substitution, script, language) {
-    var lookupTable = this.getLookupTable(script, language, feature, 1, true);
+    var lookupTable = this.getLookupTables(script, language, feature, 1, true)[0];
     var subtable = getSubstFormat(lookupTable, 2, {                // lookup type 1 subtable, format 2, coverage format 1
         substFormat: 2,
         coverage: { format: 1, glyphs: [] },
@@ -187,10 +185,10 @@ Substitution.prototype.addSingle = function(feature, substitution, script, langu
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} substitution - { sub: id, by: [ids] }
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 Substitution.prototype.addAlternate = function(feature, substitution, script, language) {
-    var lookupTable = this.getLookupTable(script, language, feature, 3, true);
+    var lookupTable = this.getLookupTables(script, language, feature, 3, true)[0];
     var subtable = getSubstFormat(lookupTable, 1, {                // lookup type 3 subtable, format 1, coverage format 1
         substFormat: 1,
         coverage: { format: 1, glyphs: [] },
@@ -213,12 +211,10 @@ Substitution.prototype.addAlternate = function(feature, substitution, script, la
  * @param {string} feature - 4-letter feature name ('liga', 'rlig', 'dlig'...)
  * @param {Object} ligature - { sub: [ids], by: id }
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 Substitution.prototype.addLigature = function(feature, ligature, script, language) {
-    script = script || 'DFLT';
-    language = language || 'DFLT';
-    var lookupTable = this.getLookupTable(script, language, feature, 4, true);
+    var lookupTable = this.getLookupTables(script, language, feature, 4, true)[0];
     var subtable = lookupTable.subtables[0];
     if (!subtable) {
         subtable = {                // lookup type 4 subtable, format 1, coverage format 1
@@ -259,12 +255,10 @@ Substitution.prototype.addLigature = function(feature, ligature, script, languag
  * List all feature data for a given script and language.
  * @param {string} feature - 4-letter feature name
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  * @return {Array} substitutions - The list of substitutions.
  */
 Substitution.prototype.getFeature = function(feature, script, language) {
-    script = script || 'DFLT';
-    language = language || 'DFLT';
     if (/ss\d\d/.test(feature)) {               // ss01 - ss20
         return this.getSingle(feature, script, language);
     }
@@ -284,11 +278,9 @@ Substitution.prototype.getFeature = function(feature, script, language) {
  * @param {string} feature - 4-letter feature name
  * @param {Object} sub - the substitution to add (an object like { sub: id or [ids], by: id or [ids] })
  * @param {string} [script='DFLT']
- * @param {string} [language='DFLT']
+ * @param {string} [language='dflt']
  */
 Substitution.prototype.add = function(feature, sub, script, language) {
-    script = script || 'DFLT';
-    language = language || 'DFLT';
     if (/ss\d\d/.test(feature)) {               // ss01 - ss20
         return this.addSingle(feature, sub, script, language);
     }

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -193,7 +193,8 @@ function parseLookupTable(data, start) {
     if (lookupType === 2) {
         var subtables = [];
         for (var i = 0; i < subTableCount; i++) {
-            subtables.push(parsePairPosSubTable(data, start + subTableOffsets[i]));
+            var pairPosSubTable = parsePairPosSubTable(data, start + subTableOffsets[i]);
+            if (pairPosSubTable) subtables.push(pairPosSubTable);
         }
         // Return a function which finds the kerning values in the subtables.
         table.getKerningValue = function(leftGlyph, rightGlyph) {

--- a/test/font.js
+++ b/test/font.js
@@ -1,0 +1,47 @@
+/* jshint mocha: true */
+
+'use strict';
+
+var assert = require('assert');
+var opentype = require('../src/opentype');
+
+describe('font.js', function() {
+
+    var font;
+
+    var fGlyph = new opentype.Glyph({ name: 'f', unicode: 102, path: new opentype.Path() });
+    var iGlyph = new opentype.Glyph({ name: 'i', unicode: 105, path: new opentype.Path() });
+    var ffGlyph = new opentype.Glyph({ name: 'f_f', unicode: 0xfb01, path: new opentype.Path() });
+    var fiGlyph = new opentype.Glyph({ name: 'f_i', unicode: 0xfb02, path: new opentype.Path() });
+    var ffiGlyph = new opentype.Glyph({ name: 'f_f_i', unicode: 0xfb03, path: new opentype.Path() });
+
+    var glyphs = [
+        new opentype.Glyph({ name: '.notdef', unicode: 0, path: new opentype.Path() }),
+        fGlyph, iGlyph, ffGlyph, fiGlyph, ffiGlyph
+    ];
+
+    beforeEach(function() {
+        font = new opentype.Font({
+            familyName: 'MyFont',
+            styleName: 'Medium',
+            unitsPerEm: 1000,
+            ascender: 800,
+            descender: -200,
+            glyphs: glyphs
+        });
+    });
+
+    describe('stringToGlyphs', function() {
+        it('must support standard ligatures', function() {
+            assert.deepEqual(font.stringToGlyphs('fi'), [fGlyph, iGlyph]);
+            font.substitution.add('liga', { sub: [1, 1, 2], by: 5 });
+            font.substitution.add('liga', { sub: [1, 1], by: 3 });
+            font.substitution.add('liga', { sub: [1, 2], by: 4 });
+            assert.deepEqual(font.stringToGlyphs('ff'), [ffGlyph]);
+            assert.deepEqual(font.stringToGlyphs('fi'), [fiGlyph]);
+            assert.deepEqual(font.stringToGlyphs('ffi'), [ffiGlyph]);
+            assert.deepEqual(font.stringToGlyphs('fffiffif'), [ffGlyph, fiGlyph, ffiGlyph, fGlyph]);
+        });
+    });
+
+});

--- a/test/layout.js
+++ b/test/layout.js
@@ -1,0 +1,70 @@
+/* jshint mocha: true */
+
+'use strict';
+
+var assert = require('assert');
+var opentype = require('../src/opentype');
+var Layout = require('../src/layout');
+
+describe('layout.js', function() {
+
+    var font;
+    var layout;
+    var notdefGlyph = new opentype.Glyph({
+        name: '.notdef',
+        unicode: 0,
+        path: new opentype.Path()
+    });
+    var defaultLayoutTable = {
+        version: 1,
+        scripts: [],
+        features: [],
+        lookups: []
+    };
+
+    var glyphs = [notdefGlyph].concat('abcdefghijklmnopqrstuvwxyz'.split('').map(function(c) {
+        return new opentype.Glyph({
+            name: c,
+            unicode: c.charCodeAt(0),
+            path: new opentype.Path()
+        });
+    }));
+
+    beforeEach(function() {
+        font = new opentype.Font({
+            familyName: 'MyFont',
+            styleName: 'Medium',
+            unitsPerEm: 1000,
+            ascender: 800,
+            descender: -200,
+            glyphs: glyphs
+        });
+        layout = new Layout(font, 'gsub');
+        layout.createDefaultTable = function() { return defaultLayoutTable; };
+    });
+
+    describe('getTable', function() {
+        it('must not always create an empty default layout table', function() {
+            assert.equal(layout.getTable(), undefined);
+            assert.equal(layout.getTable(false), undefined);
+        });
+
+        it('must create an empty default layout table on demand', function() {
+            assert.equal(layout.getTable(true), defaultLayoutTable);
+        });
+    });
+
+    describe('getScriptTable', function() {
+        it('must not create a new script table if it does not exist', function() {
+            assert.equal(layout.getScriptTable('DFLT'), undefined);
+            assert.equal(layout.getScriptTable('DFLT', false), undefined);
+        });
+
+        it('must create an new script table only on demand and if it does not exist', function() {
+            var scriptTable = layout.getScriptTable('DFLT', true);
+            assert.notEqual(scriptTable, undefined);
+            assert.notEqual(scriptTable.defaultLangSys, undefined);
+            assert.equal(layout.getScriptTable('DFLT', true), scriptTable, 'must create only one instance for each tag');
+        });
+    });
+});

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -44,14 +44,9 @@ describe('substitution.js', function() {
         substitution = new Substitution(font);
     });
 
-    describe('getGsubTable', function() {
-        it('must not create an empty default GSUB table', function() {
-            assert.equal(substitution.getGsubTable(), undefined);
-            assert.equal(substitution.getGsubTable(false), undefined);
-        });
-
-        it('can create an empty default GSUB table', function() {
-            assert.deepEqual(substitution.getGsubTable(true), {
+    describe('createDefaultTable', function() {
+        it('must return an empty default GSUB table', function() {
+            assert.deepEqual(substitution.createDefaultTable(), {
                 version: 1,
                 scripts: [{
                     tag: 'DFLT',


### PR DESCRIPTION
Add GSUB "liga" and "rlig" rendering support.
Solves #236, #230 and also #245.

Glyph rendering options are added to enable each GSUB feature individually.
Only "liga" and "rlig" are supported, and enabled by default as the spec suggests.
A "ligatures" checkbox is added to `index.html`.
Plus a small layout improvement to the glyph-inspector.

This is open for comments, especially on the options API :-)