### PR TITLE
Upgrade Travis configuration to node.js version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '6'
 deploy:
   provider: npm
   email: frederik@debleser.be


### PR DESCRIPTION
Version 0.10 has reached its end of life and is not maintained anymore.
https://github.com/nodejs/LTS#lts-schedule