### PR TITLE
Truetype Font Hinting

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ function ligaturesChanged(e) {
 }
 
 function fontSizeChanged() {
-    fontSize = fontSizeSlider.value;
+    fontSize = parseInt(fontSizeSlider.value, 10);
     document.getElementById('fontSize').innerHTML = '' + fontSize;
     renderText();
 }

--- a/src/font.js
+++ b/src/font.js
@@ -309,8 +309,9 @@ Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) 
  */
 Font.prototype.getPath = function(text, x, y, fontSize, options) {
     var fullPath = new path.Path();
+	var self = this;
     this.forEachGlyph(text, x, y, fontSize, options, function(glyph, gX, gY, gFontSize) {
-        var glyphPath = glyph.getPath(gX, gY, gFontSize, options);
+        var glyphPath = glyph.getPath(gX, gY, gFontSize, options, self);
         fullPath.extend(glyphPath);
     });
     return fullPath;

--- a/src/font.js
+++ b/src/font.js
@@ -8,7 +8,7 @@ var encoding = require('./encoding');
 var glyphset = require('./glyphset');
 var Substitution = require('./substitution');
 var util = require('./util');
-var HintingTrueType = require( './hintingtt' );
+var HintingTrueType = require('./hintingtt');
 
 /**
  * @typedef FontOptions
@@ -309,9 +309,9 @@ Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) 
  */
 Font.prototype.getPath = function(text, x, y, fontSize, options) {
     var fullPath = new path.Path();
-	var self = this;
+    var _this = this;
     this.forEachGlyph(text, x, y, fontSize, options, function(glyph, gX, gY, gFontSize) {
-        var glyphPath = glyph.getPath(gX, gY, gFontSize, options, self);
+        var glyphPath = glyph.getPath(gX, gY, gFontSize, options, _this);
         fullPath.extend(glyphPath);
     });
     return fullPath;

--- a/src/font.js
+++ b/src/font.js
@@ -8,6 +8,7 @@ var encoding = require('./encoding');
 var glyphset = require('./glyphset');
 var Substitution = require('./substitution');
 var util = require('./util');
+var HintingTrueType = require( './hintingtt' );
 
 /**
  * @typedef FontOptions
@@ -90,6 +91,15 @@ function Font(options) {
     this.encoding = new encoding.DefaultEncoding(this);
     this.substitution = new Substitution(this);
     this.tables = this.tables || {};
+
+    Object.defineProperty(this, 'hinting', {
+        get: function() {
+            if (this._hinting) return this._hinting;
+            if (this.outlinesFormat === 'truetype') {
+                return (this._hinting = new HintingTrueType(this));
+            }
+        }
+    });
 }
 
 /**
@@ -300,10 +310,9 @@ Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) 
 Font.prototype.getPath = function(text, x, y, fontSize, options) {
     var fullPath = new path.Path();
     this.forEachGlyph(text, x, y, fontSize, options, function(glyph, gX, gY, gFontSize) {
-        var glyphPath = glyph.getPath(gX, gY, gFontSize);
+        var glyphPath = glyph.getPath(gX, gY, gFontSize, options);
         fullPath.extend(glyphPath);
     });
-
     return fullPath;
 };
 

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -126,7 +126,8 @@ Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
     x = x !== undefined ? x : 0;
     y = y !== undefined ? y : 0;
     fontSize = fontSize !== undefined ? fontSize : 72;
-    var commands, hPoints;
+    var commands;
+	var hPoints;
     if (!options) options = { };
     var xScale = options.xScale;
     var yScale = options.yScale;

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -127,7 +127,7 @@ Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
     y = y !== undefined ? y : 0;
     fontSize = fontSize !== undefined ? fontSize : 72;
     var commands;
-	var hPoints;
+    var hPoints;
     if (!options) options = { };
     var xScale = options.xScale;
     var yScale = options.yScale;

--- a/src/glyph.js
+++ b/src/glyph.js
@@ -119,9 +119,10 @@ Glyph.prototype.getBoundingBox = function() {
  * @param  {number} [y=0] - Vertical position of the *baseline* of the text.
  * @param  {number} [fontSize=72] - Font size in pixels. We scale the glyph units by `1 / unitsPerEm * fontSize`.
  * @param  {Object=} options - xScale, yScale to strech the glyph.
+ * @param  {opentype.Font} if hinting is to be used, the font
  * @return {opentype.Path}
  */
-Glyph.prototype.getPath = function(x, y, fontSize, options) {
+Glyph.prototype.getPath = function(x, y, fontSize, options, font) {
     x = x !== undefined ? x : 0;
     y = y !== undefined ? y : 0;
     fontSize = fontSize !== undefined ? fontSize : 72;
@@ -130,7 +131,7 @@ Glyph.prototype.getPath = function(x, y, fontSize, options) {
     var xScale = options.xScale;
     var yScale = options.yScale;
 
-    if (options.hinting && font.hinting) {
+    if (options.hinting && font && font.hinting) {
         // in case of hinting, the hinting engine takes care
         // of scaling the points (not the path) before hinting.
         hPoints = font.hinting.exec(this, fontSize);

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -2881,7 +2881,7 @@ freedom vector = y-axis:
            pvns ... normal slope to pv
 
    y - rpdy = pvns * (x - rpdx)
-   
+
    x = p.x
 
    y = rpdy +  pvns * (p.x - rpdx)
@@ -2934,7 +2934,7 @@ generic case:
     pvns * (x - rpdx) + rpdy = fvs * (x - px) + py
 
   expand:
-    
+
     pvns * x - pvns * rpdx + rpdy = fvs * x - fvs * px + py
 
   switch:
@@ -3009,7 +3009,7 @@ arithmetic average of the movement of both refererence points.
                    .    .   20         .
                    |....|..............|
                      5        15
-     
+
 
 -------
 

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -115,7 +115,10 @@ var roundSuper = function(v) {
     var threshold = this.srThreshold;
     var sign = 1;
 
-    if (v < 0) { v = -v; sign = -1; }
+    if (v < 0) {
+        v = -v;
+        sign = -1;
+    }
 
     v += phase;
 
@@ -129,15 +132,15 @@ var roundSuper = function(v) {
 * Unit vector of x-axis.
 */
 var xUnitVector = {
-    x : 1,
+    x: 1,
 
-    y : 0,
+    y: 0,
 
-    axis : 'x',
+    axis: 'x',
 
     // Gets the projected distance between two points.
     // o1/o2 ... if true, use respective original pos.
-    distance : function(p1, p2, o1, o2) {
+    distance: function(p1, p2, o1, o2) {
         return (o1 ? p1.xo : p1.x) - (o2 ? p2.xo : p2.x);
     },
 
@@ -145,7 +148,7 @@ var xUnitVector = {
     // has the same relative position to the moved
     // positions of rp1 and rp2 than the original
     // positions had.
-    interpolate : function(p, rp1, rp2, pv) {
+    interpolate: function(p, rp1, rp2, pv) {
         var do1, do2, doa1, doa2, dm1, dm2, dt;
 
         if (!pv || pv === this) {
@@ -183,7 +186,7 @@ var xUnitVector = {
     },
 
     // slope of line normal to this
-    normalSlope : Number.NEGATIVE_INFINITY,
+    normalSlope: Number.NEGATIVE_INFINITY,
 
     // Sets the point 'p' relative to point 'rp'
     // by the distance 'd'
@@ -192,7 +195,7 @@ var xUnitVector = {
     // d   : distance on projection vector
     // pv  : projection vector (undefined = this)
     // org : if true, use original position of rp as reference.
-    setRelative : function(p, rp, d, pv, org) {
+    setRelative: function(p, rp, d, pv, org) {
         if (!pv || pv === this) {
             p.x = (org ? rp.xo : rp.x) + d;
             return;
@@ -207,31 +210,31 @@ var xUnitVector = {
     },
 
     // slope of vector line
-    slope : 0,
+    slope: 0,
 
     // Touches the point p.
-    touch : function(p) { p.xTouched = true; },
+    touch: function(p) { p.xTouched = true; },
 
     // Tests if a point p is touched.
-    touched : function(p) { return p.xTouched; },
+    touched: function(p) { return p.xTouched; },
 
     // Untouches the point p.
-    untouch : function(p) { p.xTouched = false; }
+    untouch: function(p) { p.xTouched = false; }
 };
 
 /*
 * Unit vector of y-axis.
 */
 var yUnitVector = {
-    x : 0,
+    x: 0,
 
-    y : 1,
+    y: 1,
 
-    axis : 'y',
+    axis: 'y',
 
     // Gets the projected distance between two points.
     // o1/o2 ... if true, use respective original position.
-    distance : function(p1, p2, o1, o2) {
+    distance: function(p1, p2, o1, o2) {
         return (o1 ? p1.yo : p1.y) - (o2 ? p2.yo : p2.y);
     },
     
@@ -239,7 +242,7 @@ var yUnitVector = {
     // has the same relative position to the moved
     // positions of rp1 and rp2 than the original
     // positions had.
-    interpolate : function(p, rp1, rp2, pv) {
+    interpolate: function(p, rp1, rp2, pv) {
         var do1, do2, doa1, doa2, dm1, dm2, dt;
 
         if (!pv || pv === this) {
@@ -277,12 +280,12 @@ var yUnitVector = {
     },
 
     // slope of line normal to this
-    normalSlope : 0,
+    normalSlope: 0,
 
     // Sets the point 'p' relative to point 'rp'
     // by the distance 'd'
     // org ... if true, use original position of rp as reference.
-    setRelative : function(p, rp, d, pv, org) {
+    setRelative: function(p, rp, d, pv, org) {
         if (!pv || pv === this) {
             p.y = (org ? rp.yo : rp.y) + d;
             return;
@@ -297,16 +300,16 @@ var yUnitVector = {
     },
 
     // slope of vector line
-    slope : Number.POSITIVE_INFINITY,
+    slope: Number.POSITIVE_INFINITY,
 
     // Touches the point p.
-    touch : function(p) { p.yTouched = true; },
+    touch: function(p) { p.yTouched = true; },
 
     // Tests if a point p is touched.
-    touched : function(p) { return p.yTouched; },
+    touched: function(p) { return p.yTouched; },
 
     // Untouches the point p.
-    untouch : function(p) { p.yTouched = false; }
+    untouch: function(p) { p.yTouched = false; }
 };
 
 Object.freeze(xUnitVector);

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -791,7 +791,7 @@ function exec(state) {
         if (DEBUG) state.step++;
         ins = instructionTable[prog[state.ip]];
 
-        if(!ins) {
+        if (!ins) {
             throw new Error(
                 'unknown instruction: 0x' +
                 Number(prog[state.ip]).toString(16)
@@ -923,7 +923,7 @@ function SFVTL(a, state) {
     var p2 = state.z2[p2i];
     var p1 = state.z1[p1i];
 
-    if (DEBUG) console.log('SFVTL[' + a + ']', p2i, p1i );
+    if (DEBUG) console.log('SFVTL[' + a + ']', p2i, p1i);
 
     var dx;
     var dy;
@@ -1012,7 +1012,7 @@ function ISECT(state)
     var pb0 = z1[pb0i];
     var pb1 = z1[pb1i];
     var p = state.z2[pi];
-    
+ 
     if (DEBUG) {
         console.log(
             'ISECT[], ',
@@ -1100,7 +1100,7 @@ function SZP1(state) {
 
     state.zp1 = n;
 
-    switch(n) {
+    switch (n) {
         case 0:
             if (!state.tZone) initTZone(state);
             state.z1 = state.tZone;
@@ -1141,10 +1141,10 @@ function SZPS(state) {
     var n = state.stack.pop();
 
     if (DEBUG) console.log(state.step, 'SZPS[]', n);
- 
+
     state.zp0 = state.zp1 = state.zp2 = n;
 
-    switch(n) {
+    switch (n) {
         case 0:
             if (!state.tZone) initTZone(state);
             state.z0 = state.z1 = state.z2 = state.tZone;
@@ -1367,7 +1367,7 @@ function MINDEX(state) {
 
     if (DEBUG) console.log(state.step, 'MINDEX[]', k);
 
-    stack.push(stack.splice(stack.length - k, 1)[ 0 ]);
+    stack.push(stack.splice(stack.length - k, 1)[0]);
 }
 
 // FDEF[] Function DEFinition
@@ -1396,7 +1396,7 @@ function MDAP(round, state) {
     var p = state.z0[pi];
     var fv = state.fv;
     var pv = state.pv;
-    
+
     if (DEBUG) console.log(state.step, 'MDAP[' + round + ']', pi);
 
     var d = pv.distance(p, HPZero);
@@ -1415,7 +1415,8 @@ function IUP(v, state) {
     var z2 = state.z2;
     var pLen = z2.length - 2;
     var cp;
-    var pp, np;
+    var pp;
+    var np;
 
     if (DEBUG) console.log(state.step, 'IUP[' + v.axis + ']');
 
@@ -1424,7 +1425,7 @@ function IUP(v, state) {
 
         // if this point has been touched go on
         if (v.touched(cp)) continue;
-    
+
         pp = cp.prevTouched(v);
 
         // no point on the contour has been touched?
@@ -1466,7 +1467,7 @@ function SHP(a, state) {
         if (DEBUG) {
             console.log(
                 state.step,
-                (  state.loop > 1 ?
+                (state.loop > 1 ?
                    'loop ' + (state.loop - loop) + ': ' :
                    ''
                 ) +
@@ -1494,10 +1495,10 @@ function SHC(a, state) {
 
     var d = pv.distance(rp, rp, false, true);
 
-    do{
+    do {
         if (p !== rp) fv.setRelative(p, p, d, pv);
         p = p.nextPointOnContour;
-    } while(p !== sp);
+    } while (p !== sp);
 }
 
 // SHZ[] SHift Zone using reference point
@@ -1519,7 +1520,7 @@ function SHZ(a, state) {
         case 1 : z = state.gZone; break;
         default : throw new Error('Invalid zone');
     }
-    
+
     var p;
     var d = pv.distance(rp, rp, false, true);
     var pLen = z.length - 2;
@@ -1568,7 +1569,7 @@ function IP(state) {
     var fv = state.fv;
     var pv = state.dpv;
     var z2 = state.z2;
-    
+
     while (loop--) {
         var pi = stack.pop();
         var p = z2[pi];
@@ -1597,7 +1598,7 @@ function MSIRP(a, state) {
     var rp0 = state.z0[state.rp0];
     var fv = state.fv;
     var pv = state.pv;
-    
+
     fv.setRelative(p, rp0, d, pv);
     fv.touch(p);
 
@@ -1621,7 +1622,7 @@ function ALIGNRP(state) {
 
     while (loop--) {
         var pi = stack.pop();
-        var p = z1[ pi ];
+        var p = z1[pi];
 
         if (DEBUG) console.log(
             state.step,
@@ -1658,7 +1659,7 @@ function MIAP(round, state) {
     // TODO cvtcutin should be considered here
 
     if (round) cv = state.round(cv);
-   
+
     if (DEBUG) {
         console.log(
             state.step,
@@ -1707,10 +1708,10 @@ function NPUSHW(state) {
 
     for (var i = 0; i < n; i++) {
         var w = (prog[++ip] << 8) | prog[++ip];
-        if (w & 0x8000) w = -((w^0xffff)+1);
+        if (w & 0x8000) w = -((w ^ 0xffff) + 1);
         stack.push(w);
     }
-    
+
     state.ip = ip;
 }
 
@@ -1830,7 +1831,7 @@ function LTEQ(state) {
     var stack = state.stack;
     var e2 = stack.pop();
     var e1 = stack.pop();
-    
+
     if (DEBUG) console.log(state.step, 'LTEQ[]', e2, e1);
 
     stack.push(e1 <= e2 ? 1 : 0);
@@ -1854,7 +1855,7 @@ function GTEQ(state) {
     var stack = state.stack;
     var e2 = stack.pop();
     var e1 = stack.pop();
-    
+
     if (DEBUG) console.log(state.step, 'GTEQ[]', e2, e1);
 
     stack.push(e1 >= e2 ? 1 : 0);
@@ -1868,7 +1869,7 @@ function EQ(state) {
     var e1 = stack.pop();
 
     if (DEBUG) console.log(state.step, 'EQ[]', e2, e1);
-    
+
     stack.push(e2 === e1 ? 1 : 0);
 }
 
@@ -1880,7 +1881,7 @@ function NEQ(state) {
     var e1 = stack.pop();
 
     if (DEBUG) console.log(state.step, 'NEQ[]', e2, e1);
-    
+
     stack.push(e2 !== e1 ? 1 : 0);
 }
 
@@ -1914,18 +1915,17 @@ function IF(state) {
 
     var test = state.stack.pop();
     var ins;
-    
+
     if (DEBUG) console.log(state.step, 'IF[]', test);
 
     // if test is true it just continues
     // if not the ip is skiped until matching ELSE or EIF
-    if (!test)
-    {
+    if (!test) {
         // otherwise skip forward until matching else or endif
         var nesting = 1;
-        do{
+        do {
             ins = prog[++ip];
-            switch(ins) {
+            switch (ins) {
                 case 0x1B: // ELSE
                     if (nesting === 1) nesting--;
                     break;
@@ -1936,8 +1936,8 @@ function IF(state) {
                     nesting++;
                     break;
             }
-        } while(nesting > 0);
-    
+        } while (nesting > 0);
+
         if (DEBUG) console.log(state.step, ins === 0x1B ? 'ELSE[]' : 'EIF[]');
     }
 
@@ -2005,20 +2005,20 @@ function DELTAP123(b, state) {
     var base = state.deltaBase + (b - 1) * 16;
     var ds = state.deltaShift;
     var z0 = state.z0;
-    
+
     if (DEBUG) console.log(state.step, 'DELTAP[' + b + ']', n, stack);
 
     for (var i = 0; i < n; i++)
     {
         var pi = stack.pop();
         var arg = stack.pop();
-        var appem = base + ((arg & 0xF0)>>4);
+        var appem = base + ((arg & 0xF0) >> 4);
         if (appem !== ppem) continue;
 
         var mag = (arg & 0x0F) - 8;
         if (mag >= 0) mag++;
         if (DEBUG) console.log(state.step, 'DELTAPFIX', pi, 'by', mag * ds);
-        
+
         var p = z0[pi];
         fv.setRelative(p, p, mag * ds, pv);
     }
@@ -2186,7 +2186,7 @@ function DELTAC123(b, state) {
     {
         var c = stack.pop();
         var arg = stack.pop();
-        var appem = base + ((arg & 0xF0)>>4);
+        var appem = base + ((arg & 0xF0) >> 4);
         if (appem !== ppem) continue;
 
         var mag = (arg & 0x0F) - 8;
@@ -2195,7 +2195,7 @@ function DELTAC123(b, state) {
         var delta = mag * ds;
 
         if (DEBUG) console.log(state.step, 'DELTACFIX', c, 'by', delta);
-       
+
         state.cvt[c] += delta;
     }
 }
@@ -2211,22 +2211,35 @@ function SROUND(state) {
 
     var period;
 
-    switch (n & 0xC0)
-    {
-        case 0x00: period = 0.5; break;
-        case 0x40: period = 1; break;
-        case 0x80: period = 2; break;
-        default: throw new Error('invalid SROUND value');
+    switch (n & 0xC0) {
+        case 0x00:
+            period = 0.5;
+            break;
+        case 0x40:
+            period = 1;
+            break;
+        case 0x80:
+            period = 2;
+            break;
+        default:
+            throw new Error('invalid SROUND value');
     }
 
     state.srPeriod = period;
 
-    switch (n & 0x30)
-    {
-        case 0x00: state.srPhase = 0; break;
-        case 0x10: state.srPhase = 0.25 * period; break;
-        case 0x20: state.srPhase = 0.5  * period; break;
-        case 0x30: state.srPhase = 0.75 * period; break;
+    switch (n & 0x30) {
+        case 0x00:
+            state.srPhase = 0;
+            break;
+        case 0x10:
+            state.srPhase = 0.25 * period;
+            break;
+        case 0x20:
+            state.srPhase = 0.5  * period;
+            break;
+        case 0x30:
+            state.srPhase = 0.75 * period;
+            break;
         default: throw new Error('invalid SROUND value');
     }
         
@@ -2249,21 +2262,37 @@ function S45ROUND(state) {
 
     switch (n & 0xC0)
     {
-        case 0x00: period = Math.sqrt(2) / 2; break;
-        case 0x40: period = Math.sqrt(2); break;
-        case 0x80: period = 2 * Math.sqrt(2); break;
-        default: throw new Error('invalid S45ROUND value');
+        case 0x00:
+            period = Math.sqrt(2) / 2;
+            break;
+        case 0x40:
+            period = Math.sqrt(2);
+            break;
+        case 0x80:
+            period = 2 * Math.sqrt(2);
+            break;
+        default:
+            throw new Error('invalid S45ROUND value');
     }
 
     state.srPeriod = period;
 
     switch (n & 0x30)
     {
-        case 0x00: state.srPhase = 0; break;
-        case 0x10: state.srPhase = 0.25 * period; break;
-        case 0x20: state.srPhase = 0.5  * period; break;
-        case 0x30: state.srPhase = 0.75 * period; break;
-        default: throw new Error('invalid S45ROUND value');
+        case 0x00:
+            state.srPhase = 0;
+            break;
+        case 0x10:
+            state.srPhase = 0.25 * period;
+            break;
+        case 0x20:
+            state.srPhase = 0.5  * period;
+            break;
+        case 0x30:
+            state.srPhase = 0.75 * period;
+            break;
+        default:
+            throw new Error('invalid S45ROUND value');
     }
         
     n &= 0x0F;
@@ -2292,7 +2321,7 @@ function RUTG(state) {
 // 0x7D
 function RDTG(state) {
     if (DEBUG) console.log(state.step, 'RDTG[]');
-    
+
     state.round = roundDownToGrid;
 }
 
@@ -2348,7 +2377,7 @@ function GETINFO(state) {
     // and thus those GETINFO are always 0.
 
     // opentype.js is always gray scaling
-    if (sel & 0x20) r |= 0x1000; 
+    if (sel & 0x20) r |= 0x1000;
 
     stack.push(r);
 }

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -8,7 +8,7 @@
 * This interpreter has been implemented according to this documentation:
 * https://developer.apple.com/fonts/TrueType-Reference-Manual/RM05/Chap5.html
 *
-* According to the documentation -- and thus most other implementations -- 
+* According to the documentation -- and thus most other implementations --
 * use F24DOT6 values for pixels. That means it's 1/64 pixel accurate and
 * use integer operations. However, Javascript has floating point operations
 * by default and only that's is available here. One could make a case to
@@ -34,7 +34,9 @@
 var DEBUG = false;
 
 var instructionTable;
-var exec, execComponent, execGlyph;
+var exec;
+var execComponent,
+var execGlyph;
 
 /*
 * Creates a hinting object.
@@ -61,14 +63,12 @@ function Hinting(font) {
     this._errorState = 0;
 }
 
-
 /*
 * Not rounding.
 */
 function roundOff(v) {
     return v;
 }
-
 
 /*
 * Rounding to grid.
@@ -78,14 +78,12 @@ function roundToGrid(v) {
     return Math.sign(v) * Math.round(Math.abs(v));
 }
 
-
 /*
 * Rounding to double grid.
 */
 function roundToDoubleGrid(v) {
     return Math.sign(v) * Math.round(Math.abs(v / 2)) * 2;
 }
-
 
 /*
 * Rounding to half grid.
@@ -94,7 +92,6 @@ function roundToHalfGrid(v) {
     return Math.sign(v) * Math.round(Math.abs(v * 2)) / 2;
 }
 
-
 /*
 * Rounding to up to grid.
 */
@@ -102,14 +99,12 @@ function roundUpToGrid(v) {
     return Math.sign(v) * Math.ceil(Math.abs(v));
 }
 
-
 /*
 * Rounding to down to grid.
 */
 function roundDownToGrid(v) {
     return Math.sign(v) * Math.floor(Math.abs(v));
 }
-
 
 /*
 * Super rounding.
@@ -129,7 +124,6 @@ var roundSuper = function(v) {
     if (f >= threshold) return Math.ceil(v) * sign - phase;
     else return Math.floor(v) * sign - phase;
 };
-
 
 /*
 * Unit vector of x-axis.
@@ -225,7 +219,6 @@ var xUnitVector = {
     untouch : function(p) { p.xTouched = false; }
 };
 
-
 /*
 * Unit vector of y-axis.
 */
@@ -316,10 +309,8 @@ var yUnitVector = {
     untouch : function(p) { p.yTouched = false; }
 };
 
-
 Object.freeze(xUnitVector);
 Object.freeze(yUnitVector);
-
 
 /*
 * Creates a unit vector that is not x- or y-axis.
@@ -333,7 +324,6 @@ function UnitVector(x, y) {
     Object.freeze(this);
 }
 
-
 /*
 * Gets the projected distance between two points.
 * o1/o2 ... if true, use respective original pos.
@@ -345,7 +335,6 @@ UnitVector.prototype.distance = function(p1, p2, o1, o2) {
     );
 };
 
-    
 /*
 * Moves p so it has the moved position
 * has the same relative position to the moved
@@ -371,7 +360,6 @@ UnitVector.prototype.interpolate = function(p, rp1, rp2, pv) {
     this.setRelative(p, p, (dm1 * doa2 + dm2 * doa1 ) / dt, pv, true);
 };
 
-
 /*
 * Sets the point 'p' relative to point 'rp'
 * by the distance 'd'.
@@ -395,7 +383,6 @@ UnitVector.prototype.setRelative = function(p, rp, d, pv, org) {
     p.y = fvs * (p.x - px) + py;
 };
 
-
 /*
 * Touches the point p.
 */
@@ -403,7 +390,6 @@ UnitVector.prototype.touch = function(p) {
     p.xTouched = true;
     p.yTouched = true;
 };
-
 
 /*
 * Returns a unit vector with x/y coordinates.
@@ -418,7 +404,6 @@ function getUnitVector(x, y) {
     else if( x === 0 && y === 1) return yUnitVector;
     else return new UnitVector(x, y);
 }
-
 
 /*
 * Creates a point in the hinting engine.
@@ -444,7 +429,6 @@ function HPoint(
     Object.preventExtensions(this);
 }
 
-
 /*
 * Returns the next touched point on the contour.
 */
@@ -455,7 +439,6 @@ HPoint.prototype.nextTouched = function(v) {
 
     return p;
 };
-
 
 /*
 * Returns the previous touched point on the contour
@@ -468,12 +451,10 @@ HPoint.prototype.prevTouched = function(v) {
     return p;
 };
 
-
 /*
 * The zero point.
 */
 var HPZero = Object.freeze(new HPoint(0, 0));
-
 
 /*
 * The default state of the interpreter.
@@ -491,7 +472,6 @@ var defaultState = {
     minDis : 1,           // minimum distance
     autoFlip : true
 };
-
 
 /*
 * The current state of the interpreter.
@@ -518,7 +498,6 @@ function State(env, prog) {
             this.round = roundToGrid;
     }
 }
-
 
 /*
 * Executes a glyph program.
@@ -623,7 +602,6 @@ Hinting.prototype.exec = function(glyph, ppem) {
     }
 };
 
-
 /*
 * Executes the hinting program for a glyph.
 */
@@ -710,7 +688,6 @@ function execGlyph(glyph, prepState) {
     return gZone;
 }
 
-
 /*
 * Executes the hinting program for a componenet of a multi-component glyph
 * Or of the glyph itself by a non-component glyph
@@ -780,7 +757,6 @@ function execComponent(glyph, state, xScale, yScale)
     }
 }
 
-
 /*
 * Executes the program loaded in state.
 */
@@ -849,7 +825,6 @@ function exec(state) {
         */
     }
 }
-                
 
 /*
 * Initializes the twilight zone.
@@ -871,7 +846,6 @@ function initTZone(state)
 *          And then a lot of instructions...                *
 *----------------------------------------------------------*/
 
-
 // SVTCA[a] Set freedom and projection Vectors To Coordinate Axis
 // 0x00-0x01
 function SVTCA(v, state) {
@@ -888,7 +862,6 @@ function SPVTCA(v, state) {
     state.pv = state.dpv = v;
 }
 
-
 // SFVTCA[a] Set Freedom Vector to Coordinate Axis
 // 0x04-0x05
 function SFVTCA(v, state) {
@@ -896,7 +869,6 @@ function SFVTCA(v, state) {
 
     state.fv = v;
 }
-
 
 // SPVTL[a] Set Projection Vector To Line
 // 0x06-0x07
@@ -922,7 +894,6 @@ function SPVTL(a, state) {
     state.pv = state.dpv = getUnitVector(dx, dy);
 }
 
-
 // SFVTL[a] Set Freedom Vector To Line
 // 0x08-0x09
 function SFVTL(a, state) {
@@ -947,7 +918,6 @@ function SFVTL(a, state) {
     state.fv = getUnitVector(dx, dy);
 }
 
-
 // SPVFS[] Set Projection Vector From Stack
 // 0x0A
 function SPVFS(state) {
@@ -959,7 +929,6 @@ function SPVFS(state) {
 
     state.pv = state.dpv = getUnitVector(x, y);
 }
-
 
 // SFVFS[] Set Freedom Vector From Stack
 // 0x0B
@@ -973,7 +942,6 @@ function SFVFS(state) {
     state.fv = getUnitVector(x, y);
 }
 
-
 // GPV[] Get Projection Vector
 // 0x0C
 function GPV(state) {
@@ -985,7 +953,6 @@ function GPV(state) {
     stack.push(pv.x * 0x4000);
     stack.push(pv.y * 0x4000);
 }
-
 
 // GFV[] Get Freedom Vector
 // 0x0C
@@ -999,7 +966,6 @@ function GFV(state) {
     stack.push(fv.y * 0x4000);
 }
 
-
 // SFVTPV[] Set Freedom Vector To Projection Vector
 // 0x0E
 function SFVTPV(state) {
@@ -1007,7 +973,6 @@ function SFVTPV(state) {
 
     if (DEBUG) console.log(state.step, 'SFVTPV[]');
 }
-
 
 // ISECT[] moves point p to the InterSECTion of two lines
 // 0x0F
@@ -1059,7 +1024,6 @@ function ISECT(state)
     p.y = (f1*(y3 - y4) - f2*(y1 - y2)) / div;
 }
 
-
 // SRP0[] Set Reference Point 0
 // 0x10
 function SRP0(state) {
@@ -1067,7 +1031,6 @@ function SRP0(state) {
 
     if (DEBUG) console.log(state.step, 'SRP0[]', state.rp0);
 }
-
 
 // SRP1[] Set Reference Point 1
 // 0x11
@@ -1077,7 +1040,6 @@ function SRP1(state) {
     if (DEBUG) console.log(state.step, 'SRP1[]', state.rp1);
 }
 
-
 // SRP1[] Set Reference Point 2
 // 0x12
 function SRP2(state) {
@@ -1085,7 +1047,6 @@ function SRP2(state) {
 
     if (DEBUG) console.log(state.step, 'SRP2[]', state.rp2);
 }
-
 
 // SZP0[] Set Zone Pointer 0
 // 0x13
@@ -1109,7 +1070,6 @@ function SZP0(state) {
     }
 }
 
-
 // SZP1[] Set Zone Pointer 1
 // 0x14
 function SZP1(state) {
@@ -1131,7 +1091,6 @@ function SZP1(state) {
             throw new Error('Invalid zone pointer');
     }
 }
-
 
 // SZP2[] Set Zone Pointer 2
 // 0x15
@@ -1155,7 +1114,6 @@ function SZP2(state) {
     }
 }
 
-
 // SZPS[] Set Zone PointerS
 // 0x16
 function SZPS(state) {
@@ -1178,7 +1136,6 @@ function SZPS(state) {
     }
 }
 
-
 // SLOOP[] Set LOOP variable
 // 0x17
 function SLOOP(state) {
@@ -1186,7 +1143,6 @@ function SLOOP(state) {
 
     if (DEBUG) console.log(state.step, 'SLOOP[]', state.loop);
 }
-
 
 // RTG[] Round To Grid
 // 0x18
@@ -1196,7 +1152,6 @@ function RTG(state) {
     state.round = roundToGrid;
 }
 
-
 // RTHG[] Round To Half Grid
 // 0x19
 function RTHG(state) {
@@ -1204,7 +1159,6 @@ function RTHG(state) {
 
     state.round = roundToHalfGrid;
 }
-
 
 // SMD[] Set Minimum Distance
 // 0x1A
@@ -1215,7 +1169,6 @@ function SMD(state) {
     
     state.minDis = d / 0x40;
 }
-
 
 // ELSE[] ELSE clause
 // 0x1B
@@ -1245,7 +1198,6 @@ function ELSE(state) {
     state.ip = ip;
 }
 
-
 // JMPR[] JuMP Relative
 // 0x1C
 function JMPR(state) {
@@ -1268,7 +1220,6 @@ function SCVTCI(state) {
     state.cvCutIn = n / 0x40;
 }
 
-
 // DUP[] DUPlicate top stack element
 // 0x20
 function DUP(state) {
@@ -1279,7 +1230,6 @@ function DUP(state) {
     stack.push(stack[stack.length - 1]);
 }
 
-
 // POP[] POP top stack element
 // 0x21
 function POP(state) {
@@ -1288,7 +1238,6 @@ function POP(state) {
     state.stack.pop();
 }
 
-
 // CLEAR[] CLEAR the stack
 // 0x22
 function CLEAR(state) {
@@ -1296,7 +1245,6 @@ function CLEAR(state) {
 
     state.stack.length = 0;
 }
-
 
 // SWAP[] SWAP the top two elements on the stack
 // 0x23
@@ -1312,7 +1260,6 @@ function SWAP(state) {
     stack.push(b);
 }
 
-
 // DEPTH[] DEPTH of the stack
 // 0x24
 function DEPTH(state) {
@@ -1322,7 +1269,6 @@ function DEPTH(state) {
 
     stack.push( stack.length );
 }
-
 
 // LOOPCALL[] LOOPCALL function
 // 0x2A
@@ -1378,7 +1324,6 @@ function CALL(state) {
     if (DEBUG) console.log(++state.step, 'returning from', fn);
 }
 
-
 // CINDEX[] Copy the INDEXed element to the top of the stack
 // 0x25
 function CINDEX(state) {
@@ -1393,7 +1338,6 @@ function CINDEX(state) {
     // thus stack.length - k.
 }
 
-
 // MINDEX[] Move the INDEXed element to the top of the stack
 // 0x26
 function MINDEX(state) {
@@ -1404,7 +1348,6 @@ function MINDEX(state) {
 
     stack.push(stack.splice(stack.length - k, 1)[ 0 ]);
 }
-
 
 // FDEF[] Function DEFinition
 // 0x2C
@@ -1425,7 +1368,6 @@ function FDEF(state) {
     state.funcs[fn] = prog.slice(ipBegin + 1, ip);
 }
 
-
 // MDAP[a] Move Direct Absolute Point
 // 0x2E-0x2F
 function MDAP(round, state) {
@@ -1445,7 +1387,6 @@ function MDAP(round, state) {
 
     state.rp0 = state.rp1 = pi;
 }
-
 
 // IUP[a] Interpolate Untouched Points through the outline
 // 0x30
@@ -1481,7 +1422,6 @@ function IUP(v, state) {
     }
 }
 
-
 // SHP[] SHift Point using reference point
 // 0x32-0x33
 function SHP(a, state) {
@@ -1505,7 +1445,7 @@ function SHP(a, state) {
         if (DEBUG) {
             console.log(
                 state.step,
-                (  state.loop > 1 ? 
+                (  state.loop > 1 ?
                    'loop ' + (state.loop - loop) + ': ' :
                    ''
                 ) +
@@ -1516,7 +1456,6 @@ function SHP(a, state) {
 
     state.loop = 1;
 }
-
 
 // SHC[] SHift Contour using reference point
 // 0x36-0x37
@@ -1539,7 +1478,6 @@ function SHC(a, state) {
         p = p.nextPointOnContour;
     } while(p !== sp);
 }
-
 
 // SHZ[] SHift Zone using reference point
 // 0x36-0x37
@@ -1571,7 +1509,6 @@ function SHZ(a, state) {
     }
 }
 
-
 // SHPIX[] SHift point by a PIXel amount
 // 0x38
 function SHPIX(state) {
@@ -1597,7 +1534,6 @@ function SHPIX(state) {
 
     state.loop = 1;
 }
-
 
 // IP[] Interpolate Point
 // 0x39
@@ -1630,7 +1566,6 @@ function IP(state) {
     state.loop = 1;
 }
 
-
 // MSIRP[a] Move Stack Indirect Relative Point
 // 0x3A-0x3B
 function MSIRP(a, state) {
@@ -1651,8 +1586,6 @@ function MSIRP(a, state) {
     state.rp2 = pi;
     if (a) state.rp0 = pi;
 }
-
-
 
 // ALIGNRP[] Align to reference point.
 // 0x3C
@@ -1682,7 +1615,6 @@ function ALIGNRP(state) {
     state.loop = 1;
 }
 
-
 // RTG[] Round To Double Grid
 // 0x3D
 function RTDG(state) {
@@ -1690,7 +1622,6 @@ function RTDG(state) {
 
     state.round = roundToDoubleGrid;
 }
-
 
 // MIAP[a] Move Indirect Absolute Point
 // 0x3E-0x3F
@@ -1727,7 +1658,6 @@ function MIAP(round, state) {
     state.rp0 = state.rp1 = pi;
 }
 
-
 // NPUSB[] PUSH N Bytes
 // 0x40
 function NPUSHB(state) {
@@ -1743,7 +1673,6 @@ function NPUSHB(state) {
 
     state.ip = ip;
 }
-
 
 // NPUSHW[] PUSH N Words
 // 0x41
@@ -1764,7 +1693,6 @@ function NPUSHW(state) {
     state.ip = ip;
 }
 
-
 // WS[] Write Store
 // 0x42
 function WS(state) {
@@ -1781,7 +1709,6 @@ function WS(state) {
     store[l] = v;
 }
 
-
 // RS[] Read Store
 // 0x43
 function RS(state) {
@@ -1797,7 +1724,6 @@ function RS(state) {
     stack.push(v);
 }
 
-
 // WCVTP[] Write Control Value Table in Pixel units
 // 0x44
 function WCVTP(state) {
@@ -1811,7 +1737,6 @@ function WCVTP(state) {
     state.cvt[l] = v / 0x40;
 }
 
-
 // RCVT[] Read Control Value Table entry
 // 0x45
 function RCVT(state) {
@@ -1822,7 +1747,6 @@ function RCVT(state) {
 
     stack.push(state.cvt[cvte] * 0x40);
 }
-
 
 // GC[] Get Coordinate projected onto the projection vector
 // 0x46-0x47
@@ -1836,7 +1760,6 @@ function GC(a, state) {
     var d = state.dpv.distance(p, HPZero, a, false);
     stack.push(d * 0x40);
 }
-
 
 // MD[a] Measure Distance
 // 0x49-0x4A
@@ -1853,7 +1776,6 @@ function MD(a, state) {
     state.stack.push(Math.round(d * 64));
 }
 
-
 // MPPEM[] Measure Pixels Per EM
 // 0x4B
 function MPPEM(state) {
@@ -1861,14 +1783,12 @@ function MPPEM(state) {
     state.stack.push(state.ppem);
 }
 
-
 // FLIPON[] set the auto FLIP Boolean to ON
 // 0x4D
 function FLIPON(state) {
     if (DEBUG) console.log(state.step, 'FLIPON[]');
     state.autoFlip = true;
 }
-
 
 // LT[] Less Than
 // 0x50
@@ -1883,7 +1803,6 @@ function LT(state) {
     stack.push(e1 < e2 ? 1 : 0);
 }
 
-
 // LTEQ[] Less Than or EQual
 // 0x53
 function LTEQ(state) {
@@ -1895,7 +1814,6 @@ function LTEQ(state) {
 
     stack.push(e1 <= e2 ? 1 : 0);
 }
-
 
 // GTEQ[] Greater Than
 // 0x52
@@ -1909,7 +1827,6 @@ function GT(state) {
     stack.push(e1 > e2 ? 1 : 0);
 }
 
-
 // GTEQ[] Greater Than or EQual
 // 0x53
 function GTEQ(state) {
@@ -1921,7 +1838,6 @@ function GTEQ(state) {
 
     stack.push(e1 >= e2 ? 1 : 0);
 }
-
 
 // EQ[] EQual
 // 0x54
@@ -1935,7 +1851,6 @@ function EQ(state) {
     stack.push(e2 === e1 ? 1 : 0);
 }
 
-
 // NEQ[] Not EQual
 // 0x55
 function NEQ(state) {
@@ -1948,7 +1863,6 @@ function NEQ(state) {
     stack.push(e2 !== e1 ? 1 : 0);
 }
 
-
 // ODD[] ODD
 // 0x56
 function ODD(state) {
@@ -1960,7 +1874,6 @@ function ODD(state) {
     stack.push(Math.trunc(n) % 2 ? 1 : 0);
 }
 
-
 // EVEN[] EVEN
 // 0x57
 function EVEN(state) {
@@ -1971,7 +1884,6 @@ function EVEN(state) {
 
     stack.push(Math.trunc(n) % 2 ? 0 : 1);
 }
-
 
 // IF[] IF test
 // 0x58
@@ -2011,7 +1923,6 @@ function IF(state) {
     state.ip = ip;
 }
 
-
 // EIF[] End IF
 // 0x59
 function EIF(state) {
@@ -2021,7 +1932,6 @@ function EIF(state) {
     
     if (DEBUG) console.log(state.step, 'EIF[]');
 }
-
 
 // AND[] logical AND
 // 0x5A
@@ -2036,7 +1946,6 @@ function AND(state) {
     stack.push(e2 && e1 ? 1 : 0);
 }
 
-
 // OR[] logical OR
 // 0x5B
 function OR(state) {
@@ -2050,7 +1959,6 @@ function OR(state) {
     stack.push(e2 || e1 ? 1 : 0);
 }
 
-
 // NOT[] logical NOT
 // 0x5C
 function NOT(state) {
@@ -2062,7 +1970,6 @@ function NOT(state) {
 
     stack.push(e ? 0 : 1);
 }
-
 
 // DELTAP1[] DELTA exception P1
 // DELTAP2[] DELTA exception P2
@@ -2096,7 +2003,6 @@ function DELTAP123(b, state) {
     }
 }
 
-
 // SDB[] Set Delta Base in the graphics state
 // 0x5E
 function SDB(state) {
@@ -2109,7 +2015,6 @@ function SDB(state) {
     state.deltaBase = n;
 }
 
-
 // SDS[] Set Delta Shift in the graphics state
 // 0x5F
 function SDS(state) {
@@ -2121,7 +2026,6 @@ function SDS(state) {
 
     state.deltaShift = Math.pow(0.5, n);
 }
-
 
 // ADD[] ADD
 // 0x60
@@ -2136,7 +2040,6 @@ function ADD(state) {
     stack.push(n1 + n2);
 }
 
-
 // SUB[] SUB
 // 0x61
 function SUB(state) {
@@ -2149,7 +2052,6 @@ function SUB(state) {
 
     stack.push(n1 - n2);
 }
-
 
 // DIV[] DIV
 // 0x62
@@ -2164,7 +2066,6 @@ function DIV(state) {
     stack.push(n1 * 64 / n2);
 }
 
-
 // MUL[] MUL
 // 0x63
 function MUL(state) {
@@ -2178,7 +2079,6 @@ function MUL(state) {
     stack.push(n1 * n2 / 64);
 }
 
-
 // ABS[] ABSolute value
 // 0x64
 function ABS(state) {
@@ -2189,8 +2089,6 @@ function ABS(state) {
 
     stack.push(Math.abs(n));
 }
-
-
 
 // NEG[] NEGate
 // 0x65
@@ -2203,7 +2101,6 @@ function NEG(state) {
     stack.push(-n);
 }
 
-
 // FLOOR[] FLOOR
 // 0x66
 function FLOOR(state) {
@@ -2215,7 +2112,6 @@ function FLOOR(state) {
     stack.push(Math.floor(n / 0x40) * 0x40);
 }
 
-
 // CEILING[] CEILING
 // 0x67
 function CEILING(state) {
@@ -2226,7 +2122,6 @@ function CEILING(state) {
 
     stack.push(Math.ceil(n / 0x40) * 0x40);
 }
-
 
 // ROUND[ab] ROUND value
 // 0x68-0x6B
@@ -2240,7 +2135,6 @@ function ROUND(dt, state) {
     stack.push(state.round(n / 0x40) * 0x40);
 }
 
-
 // WCVTF[] Write Control Value Table in Funits
 // 0x70
 function WCVTF(state) {
@@ -2253,7 +2147,6 @@ function WCVTF(state) {
 
     state.cvt[l] = v * state.ppem / state.font.unitsPerEm;
 }
-
 
 // DELTAC1[] DELTA exception C1
 // DELTAC2[] DELTA exception C2
@@ -2285,7 +2178,6 @@ function DELTAC123(b, state) {
         state.cvt[c] += delta;
     }
 }
-
 
 // SROUND[] Super ROUND
 // 0x76
@@ -2323,7 +2215,6 @@ function SROUND(state) {
     else state.srThreshold = (n/8 - 0.5) * period;
 }
 
-
 // S45ROUND[] Super ROUND 45 degrees
 // 0x77
 function S45ROUND(state) {
@@ -2360,7 +2251,6 @@ function S45ROUND(state) {
     else state.srThreshold = (n/8 - 0.5) * period;
 }
 
-
 // ROFF[] Round Off
 // 0x7A
 function ROFF(state) {
@@ -2368,7 +2258,6 @@ function ROFF(state) {
 
     state.round = roundOff;
 }
-
 
 // RUTG[] Round Up To Grid
 // 0x7C
@@ -2378,7 +2267,6 @@ function RUTG(state) {
     state.round = roundUpToGrid;
 }
 
-
 // RDTG[] Round Down To Grid
 // 0x7D
 function RDTG(state) {
@@ -2386,7 +2274,6 @@ function RDTG(state) {
     
     state.round = roundDownToGrid;
 }
-
 
 // SCANCTRL[] SCAN conversion ConTRoL
 // 0x85
@@ -2397,8 +2284,6 @@ function SCANCTRL(state) {
 
     if (DEBUG) console.log(state.step, 'SCANCTRL[]', n);
 }
-
-
 
 // SDPVTL[a] Set Dual Projection Vector To Line
 // 0x86-0x87
@@ -2426,7 +2311,6 @@ function SDPVTL(a, state) {
     state.dpv = getUnitVector(dx, dy);
 }
 
-
 // GETINFO[] GET INFOrmation
 // 0x88
 function GETINFO(state) {
@@ -2448,7 +2332,6 @@ function GETINFO(state) {
     stack.push(r);
 }
 
-
 // ROLL[] ROLL the top three stack elements
 // 0x8A
 function ROLL(state) {
@@ -2465,7 +2348,6 @@ function ROLL(state) {
     stack.push(c);
 }
 
-
 // MAX[] MAXimum of top two stack elements
 // 0x8B
 function MAX(state) {
@@ -2478,7 +2360,6 @@ function MAX(state) {
 
     stack.push(Math.max(e1, e2));
 }
-
 
 // MIN[] MINimum of top two stack elements
 // 0x8C
@@ -2493,7 +2374,6 @@ function MIN(state) {
     stack.push(Math.min(e1, e2));
 }
 
-
 // SCANTYPE[] SCANTYPE
 // 0x8D
 function SCANTYPE(state) {
@@ -2503,7 +2383,6 @@ function SCANTYPE(state) {
 
     if (DEBUG) console.log(state.step, 'SCANTYPE[]', n);
 }
-
 
 // INSTCTRL[] INSTCTRL
 // 0x8D
@@ -2520,7 +2399,6 @@ function INSTCTRL(state) {
     }
 }
 
-
 // PUSHB[abc] PUSH Bytes
 // 0xB0-0xB7
 function PUSHB(n, state) {
@@ -2534,7 +2412,6 @@ function PUSHB(n, state) {
 
     state.ip = ip;
 }
-
 
 // PUSHW[abc] PUSH Words
 // 0xB8-0xBF
@@ -2553,7 +2430,6 @@ function PUSHW(n, state) {
     
     state.ip = ip;
 }
-
 
 // MDRP[abcde] Move Direct Relative Point
 // 0xD0-0xEF
@@ -2621,7 +2497,6 @@ function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
     state.rp2 = pi;
     if (setRp0) state.rp0 = pi;
 }
-
 
 /*
 * The instruction table.
@@ -2885,9 +2760,7 @@ instructionTable = [
     /* 0xFF */ MDRP_MIRP.bind(undefined, 1, 1, 1, 1, 3)
 ];
 
-
 module.exports = Hinting;
-
 
 /*****************************
   Mathematical Considertions
@@ -3082,9 +2955,9 @@ arithmetic average of the movement of both refererence points.
          .         .                   .         .
          .    10   .          30       .         .
          |.........|.............................|
-                   .                   .         
+                   .                   .
                    . (+5)              .
-                po *--->* p            .         
+                po *--->* p            .
                    .    .              .
                    .    .   20         .
                    |....|..............|

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -35,7 +35,7 @@ var DEBUG = false;
 
 var instructionTable;
 var exec;
-var execComponent,
+var execComponent;
 var execGlyph;
 
 /*

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -529,7 +529,7 @@ function State(env, prog) {
 * ppem: the size the glyph is rendered for
 */
 Hinting.prototype.exec = function(glyph, ppem) {
-    if (typeof(ppem) !== 'number') {
+    if (typeof ppem !== 'number') {
         throw new Error('Point size is not a number!');
     }
 
@@ -703,7 +703,7 @@ function execGlyph(glyph, prepState) {
             gZone.length -= 2;
         }
     }
-    
+
     return gZone;
 }
 
@@ -732,7 +732,7 @@ function execComponent(glyph, state, xScale, yScale)
             cp.onCurve
         );
     }
-    
+
     // loops again to chain link the contours
     var sp; // start point
     var np; // next point
@@ -790,16 +790,16 @@ function exec(state) {
     for (state.ip = 0; state.ip < pLen; state.ip++) {
         if (DEBUG) state.step++;
         ins = instructionTable[prog[state.ip]];
-        
+
         if(!ins) {
             throw new Error(
                 'unknown instruction: 0x' +
                 Number(prog[state.ip]).toString(16)
             );
         }
-       
+
         ins(state);
-        
+
         // very extensive debugging for each step
         /*
         if (DEBUG) {
@@ -818,7 +818,7 @@ function exec(state) {
                 }
                 console.log('GZ', da);
             }
-            
+
             if (state.tZone) {
                 da = [];
                 for (i = 0; i < state.tZone.length; i++) {
@@ -898,9 +898,10 @@ function SPVTL(a, state) {
     var p2 = state.z2[p2i];
     var p1 = state.z1[p1i];
 
-    if (DEBUG) console.log( 'SPVTL[' + a + ']', p2i, p1i );
+    if (DEBUG) console.log('SPVTL[' + a + ']', p2i, p1i);
 
-    var dx, dy;
+    var dx;
+    var dy;
 
     if (!a) {
         dx = p1.x - p2.x;
@@ -922,9 +923,10 @@ function SFVTL(a, state) {
     var p2 = state.z2[p2i];
     var p1 = state.z1[p1i];
 
-    if (DEBUG) console.log( 'SFVTL[' + a + ']', p2i, p1i );
+    if (DEBUG) console.log('SFVTL[' + a + ']', p2i, p1i );
 
-    var dx, dy;
+    var dx;
+    var dy;
 
     if (!a) {
         dx = p1.x - p2.x;
@@ -1034,13 +1036,13 @@ function ISECT(state)
     var x4 = pb1.x;
     var y4 = pb1.y;
 
-    var div = (x1 - x2)*(y3 - y4) - (y1 - y2)*(x3 - x4);
-    var f1 = x1*y2 - y1*x2;
-    var f2 = x3*y4 - y3*x4; 
+    var div = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+    var f1 = x1 * y2 - y1 * x2;
+    var f2 = x3 * y4 - y3 * x4;
 
-    p.x = (f1*(x3 - x4) - f2*(x1 - x2)) / div;
+    p.x = (f1 * (x3 - x4) - f2 * (x1 - x2)) / div;
 
-    p.y = (f1*(y3 - y4) - f2*(y1 - y2)) / div;
+    p.y = (f1 * (y3 - y4) - f2 * (y1 - y2)) / div;
 }
 
 // SRP0[] Set Reference Point 0
@@ -1073,10 +1075,10 @@ function SZP0(state) {
     var n = state.stack.pop();
 
     if (DEBUG) console.log(state.step, 'SZP0[]', n);
- 
+
     state.zp0 = n;
 
-    switch(n) {
+    switch (n) {
         case 0:
             if (!state.tZone) initTZone(state);
             state.z0 = state.tZone;
@@ -1095,7 +1097,7 @@ function SZP1(state) {
     var n = state.stack.pop();
 
     if (DEBUG) console.log(state.step, 'SZP1[]', n);
- 
+
     state.zp1 = n;
 
     switch(n) {
@@ -1185,7 +1187,7 @@ function SMD(state) {
     var d = state.stack.pop();
 
     if (DEBUG) console.log(state.step, 'SMD[]', d);
-    
+
     state.minDis = d / 0x40;
 }
 
@@ -1202,9 +1204,9 @@ function ELSE(state) {
     // otherwise skip forward until matching else or endif
     var nesting = 1;
     var ins;
-    do{
+    do {
         ins = prog[++ip];
-        switch(ins) {
+        switch (ins) {
             case 0x59: // EIF
                 nesting--;
                 break;
@@ -1212,9 +1214,9 @@ function ELSE(state) {
                 nesting++;
                 break;
         }
-    } while(nesting > 0);
+    } while (nesting > 0);
 
-    state.ip = ip;
+    state.i p = ip;
 }
 
 // JMPR[] JuMP Relative
@@ -1286,7 +1288,7 @@ function DEPTH(state) {
 
     if (DEBUG) console.log(state.step, 'DEPTH[]');
 
-    stack.push( stack.length );
+    stack.push(stack.length);
 }
 
 // LOOPCALL[] LOOPCALL function

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -2603,15 +2603,15 @@ function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
     if (DEBUG) {
         console.log(
             state.step,
-            ( indirect ? 'MIRP[' : 'MDRP[' )
-            + (setRp0 ? 'M' : 'm')
-            + (keepD ? '>' : '_')
-            + (ro ? 'R' : '_')
-            + (dt === 0 ? 'Gr' : (dt === 1 ? 'Bl' : (dt === 2 ? 'Wh' : '')))
-            + ']',
-            indirect
-                ?  cvte + '(' + state.cvt[cvte] + ',' +  cv + ')'
-                : '',
+            ( indirect ? 'MIRP[' : 'MDRP[' ) +
+            (setRp0 ? 'M' : 'm') +
+            (keepD ? '>' : '_') +
+            (ro ? 'R' : '_') +
+            (dt === 0 ? 'Gr' : (dt === 1 ? 'Bl' : (dt === 2 ? 'Wh' : ''))) +
+            ']',
+            indirect ?
+                cvte + '(' + state.cvt[cvte] + ',' +  cv + ')' :
+                '',
             pi,
             '(d =', od, '->', sign * d, ')'
         );

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -149,7 +149,13 @@ var xUnitVector = {
     // positions of rp1 and rp2 than the original
     // positions had.
     interpolate: function(p, rp1, rp2, pv) {
-        var do1, do2, doa1, doa2, dm1, dm2, dt;
+        var do1;
+        var do2;
+        var doa1;
+        var doa2;
+        var dm1;
+        var dm2;
+        var dt;
 
         if (!pv || pv === this) {
             do1 = p.xo - rp1.xo;
@@ -206,7 +212,7 @@ var xUnitVector = {
         var rpdx = rpx + d * pv.x;
         var rpdy = rpy + d * pv.y;
 
-        p.x = rpdx + ( p.y - rpdy ) / pv.normalSlope;
+        p.x = rpdx + (p.y - rpdy) / pv.normalSlope;
     },
 
     // slope of vector line
@@ -237,13 +243,19 @@ var yUnitVector = {
     distance: function(p1, p2, o1, o2) {
         return (o1 ? p1.yo : p1.y) - (o2 ? p2.yo : p2.y);
     },
-    
+
     // Moves p so it has the moved position
     // has the same relative position to the moved
     // positions of rp1 and rp2 than the original
     // positions had.
     interpolate: function(p, rp1, rp2, pv) {
-        var do1, do2, doa1, doa2, dm1, dm2, dt;
+        var do1;
+        var do2;
+        var doa1;
+        var doa2;
+        var dm1;
+        var dm2;
+        var dt;
 
         if (!pv || pv === this) {
             do1 = p.yo - rp1.yo;
@@ -323,7 +335,7 @@ function UnitVector(x, y) {
     this.y = y;
     this.axis = undefined;
     this.slope = y / x;
-    this.normalSlope = - x / y;
+    this.normalSlope = -x / y;
     Object.freeze(this);
 }
 
@@ -332,7 +344,7 @@ function UnitVector(x, y) {
 * o1/o2 ... if true, use respective original pos.
 */
 UnitVector.prototype.distance = function(p1, p2, o1, o2) {
-    return(
+    return (
         this.x * xUnitVector.distance(p1, p2, o1, o2) +
         this.y * yUnitVector.distance(p1, p2, o1, o2)
     );
@@ -345,8 +357,14 @@ UnitVector.prototype.distance = function(p1, p2, o1, o2) {
 * positions had.
 */
 UnitVector.prototype.interpolate = function(p, rp1, rp2, pv) {
-    var dm1, dm2, do1, do2, doa1, doa2, dt;
-        
+    var dm1;
+    var dm2;
+    var do1;
+    var do2;
+    var doa1;
+    var doa2;
+    var dt;
+
     do1 = pv.distance(p, rp1, true, true);
     do2 = pv.distance(p, rp2, true, true);
     dm1 = pv.distance(rp1, rp1, false, true);
@@ -360,7 +378,7 @@ UnitVector.prototype.interpolate = function(p, rp1, rp2, pv) {
         return;
     }
 
-    this.setRelative(p, p, (dm1 * doa2 + dm2 * doa1 ) / dt, pv, true);
+    this.setRelative(p, p, (dm1 * doa2 + dm2 * doa1) / dt, pv, true);
 };
 
 /*
@@ -369,7 +387,7 @@ UnitVector.prototype.interpolate = function(p, rp1, rp2, pv) {
 * org ... if true, use original position of rp as reference
 */
 UnitVector.prototype.setRelative = function(p, rp, d, pv, org) {
-    if (!pv) pv = this;
+    pv = pv || this;
 
     var rpx = org ? rp.xo : rp.x;
     var rpy = org ? rp.yo : rp.y;
@@ -403,8 +421,8 @@ function getUnitVector(x, y) {
     x /= d;
     y /= d;
 
-    if( x === 1 && y === 0) return xUnitVector;
-    else if( x === 0 && y === 1) return yUnitVector;
+    if (x === 1 && y === 0) return xUnitVector;
+    else if (x === 0 && y === 1) return yUnitVector;
     else return new UnitVector(x, y);
 }
 
@@ -417,10 +435,8 @@ function HPoint(
     lastPointOfContour,
     onCurve
 ) {
-    // possibly may add rounding to 1/64 pixel here to behave exactly like
-    // other font engines...
-    this.x = this.xo = Math.round(x*64)/64; // hinted x value and original x-value
-    this.y = this.yo = Math.round(y*64)/64; // hinted y value and original y-value
+    this.x = this.xo = Math.round(x * 64) / 64; // hinted x value and original x-value
+    this.y = this.yo = Math.round(y * 64) / 64; // hinted y value and original y-value
 
     this.lastPointOfContour = lastPointOfContour;
     this.onCurve = onCurve;
@@ -468,12 +484,12 @@ var HPZero = Object.freeze(new HPoint(0, 0));
 * ever change.
 */
 var defaultState = {
-    cvCutIn : 17 / 16,    // control value cut in
-    deltaBase : 9,
-    deltaShift : 0.125,
-    loop : 1,             // loops some instructions
-    minDis : 1,           // minimum distance
-    autoFlip : true
+    cvCutIn: 17 / 16,    // control value cut in
+    deltaBase: 9,
+    deltaShift: 0.125,
+    loop: 1,             // loops some instructions
+    minDis: 1,           // minimum distance
+    autoFlip: true
 };
 
 /*
@@ -487,7 +503,7 @@ function State(env, prog) {
     this.stack = [];
     this.prog = prog;
 
-    switch(env) {
+    switch (env) {
         case 'glyf' :
             this.zp0 = 1;
             this.zp1 = 1;
@@ -523,7 +539,7 @@ Hinting.prototype.exec = function(glyph, ppem) {
     var font = this.font;
     var prepState = this._prepState;
 
-    if(!prepState || prepState.ppem !== ppem) {
+    if (!prepState || prepState.ppem !== ppem) {
         var fpgmState = this._fpgmState;
 
         if (!fpgmState) {
@@ -543,9 +559,9 @@ Hinting.prototype.exec = function(glyph, ppem) {
                 fpgmState.step = -1;
             }
 
-            try{
+            try {
                 exec(fpgmState);
-            } catch(e) {
+            } catch (e) {
                 console.log('Hinting error in FPGM:' + e);
                 this._errorState = 3;
                 return;
@@ -570,7 +586,7 @@ Hinting.prototype.exec = function(glyph, ppem) {
             var cvt = prepState.cvt = new Array(oCvt.length);
             var scale = ppem / font.unitsPerEm;
             for (var c = 0; c < oCvt.length; c++) {
-               cvt[c] = oCvt[c] * scale;
+                cvt[c] = oCvt[c] * scale;
             }
         } else {
             prepState.cvt = [];
@@ -581,9 +597,9 @@ Hinting.prototype.exec = function(glyph, ppem) {
             prepState.step = -1;
         }
 
-        try{
+        try {
             exec(prepState);
-        } catch(e) {
+        } catch (e) {
             if (this._errorState < 2) {
                 console.log('Hinting error in PREP:' + e);
             }
@@ -593,9 +609,9 @@ Hinting.prototype.exec = function(glyph, ppem) {
 
     if (this._errorState > 1) return;
 
-    try{
+    try {
         return execGlyph(glyph, prepState);
-    } catch(e) {
+    } catch (e) {
         if (this._errorState < 1) {
             console.log('Hinting error:' + e);
             console.log('Note: further hinting errors are silenced');
@@ -630,7 +646,7 @@ function execGlyph(glyph, prepState) {
         var font = prepState.font;
         gZone = [];
         contours = [];
-        for(var i = 0; i < components.length; i++) {
+        for (var i = 0; i < components.length; i++) {
             var c = components[i];
             var cg = font.glyphs.get(c.glyphIndex);
 
@@ -648,7 +664,7 @@ function execGlyph(glyph, prepState) {
             var dy = Math.round(c.dy * yScale);
             var gz = state.gZone;
             var cc = state.contours;
-            for(var pi = 0; pi < gz.length; pi++) {
+            for (var pi = 0; pi < gz.length; pi++) {
                 var p = gz[pi];
                 p.xTouched = p.yTouched = false;
                 p.xo = p.x = p.x + dx;
@@ -657,7 +673,7 @@ function execGlyph(glyph, prepState) {
 
             var gLen = gZone.length;
             gZone.push.apply(gZone, gz);
-            for(var j = 0; j < cc.length; j++) {
+            for (var j = 0; j < cc.length; j++) {
                 contours.push(cc[j] + gLen);
             }
         }
@@ -771,7 +787,7 @@ function exec(state) {
     var pLen = prog.length;
     var ins;
 
-    for(state.ip = 0; state.ip < pLen; state.ip++) {
+    for (state.ip = 0; state.ip < pLen; state.ip++) {
         if (DEBUG) state.step++;
         ins = instructionTable[prog[state.ip]];
         
@@ -787,10 +803,11 @@ function exec(state) {
         // very extensive debugging for each step
         /*
         if (DEBUG) {
-            var da, i;
+            var da;
+            var i;
             if (state.gZone) {
                 da = [];
-                for(i = 0; i < state.gZone.length; i++)
+                for (i = 0; i < state.gZone.length; i++)
                 {
                     da.push(i + ' ' +
                         state.gZone[i].x * 64 + ' ' +
@@ -804,8 +821,7 @@ function exec(state) {
             
             if (state.tZone) {
                 da = [];
-                for(i = 0; i < state.tZone.length; i++)
-                {
+                for (i = 0; i < state.tZone.length; i++) {
                     da.push(i + ' ' +
                         state.tZone[i].x * 64 + ' ' +
                         state.tZone[i].y * 64 + ' ' +
@@ -839,7 +855,7 @@ function initTZone(state)
     var tZone = state.tZone = new Array(state.gZone.length);
 
     // no idea if this is actually correct...
-    for(var i = 0; i < tZone.length; i++)
+    for (var i = 0; i < tZone.length; i++)
     {
         tZone[i] = new HPoint(0, 0);
     }
@@ -1289,7 +1305,7 @@ function LOOPCALL(state) {
     state.prog = state.funcs[fn];
 
     // executes the function
-    for(var i = 0; i < c; i++) {
+    for (var i = 0; i < c; i++) {
         exec(state);
 
         if (DEBUG) console.log(
@@ -1990,7 +2006,7 @@ function DELTAP123(b, state) {
     
     if (DEBUG) console.log(state.step, 'DELTAP[' + b + ']', n, stack);
 
-    for(var i = 0; i < n; i++)
+    for (var i = 0; i < n; i++)
     {
         var pi = stack.pop();
         var arg = stack.pop();
@@ -2164,7 +2180,7 @@ function DELTAC123(b, state) {
 
     if (DEBUG) console.log(state.step, 'DELTAC[' + b + ']', n, stack);
 
-    for(var i = 0; i < n; i++)
+    for (var i = 0; i < n; i++)
     {
         var c = stack.pop();
         var arg = stack.pop();

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -1216,7 +1216,7 @@ function ELSE(state) {
         }
     } while (nesting > 0);
 
-    state.i p = ip;
+    state.ip = ip;
 }
 
 // JMPR[] JuMP Relative

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -1012,7 +1012,7 @@ function ISECT(state)
     var pb0 = z1[pb0i];
     var pb1 = z1[pb1i];
     var p = state.z2[pi];
- 
+
     if (DEBUG) {
         console.log(
             'ISECT[], ',
@@ -1119,10 +1119,10 @@ function SZP2(state) {
     var n = state.stack.pop();
 
     if (DEBUG) console.log(state.step, 'SZP2[]', n);
- 
+
     state.zp2 = n;
 
-    switch(n) {
+    switch (n) {
         case 0:
             if (!state.tZone) initTZone(state);
             state.z2 = state.tZone;
@@ -1515,7 +1515,7 @@ function SHZ(a, state) {
     if (DEBUG) console.log(state.step, 'SHZ[' + a + ']', e);
 
     var z;
-    switch(e) {
+    switch (e) {
         case 0 : z = state.tZone; break;
         case 1 : z = state.gZone; break;
         default : throw new Error('Invalid zone');
@@ -1950,7 +1950,7 @@ function EIF(state) {
     // this can be reached normally when
     // executing an else branch.
     // -> just ignore it
-    
+
     if (DEBUG) console.log(state.step, 'EIF[]');
 }
 
@@ -2242,11 +2242,11 @@ function SROUND(state) {
             break;
         default: throw new Error('invalid SROUND value');
     }
-        
+
     n &= 0x0F;
-    
-    if( n === 0 ) state.srThreshold = 0;
-    else state.srThreshold = (n/8 - 0.5) * period;
+
+    if (n === 0) state.srThreshold = 0;
+    else state.srThreshold = (n / 8 - 0.5) * period;
 }
 
 // S45ROUND[] Super ROUND 45 degrees
@@ -2260,8 +2260,7 @@ function S45ROUND(state) {
 
     var period;
 
-    switch (n & 0xC0)
-    {
+    switch (n & 0xC0) {
         case 0x00:
             period = Math.sqrt(2) / 2;
             break;
@@ -2277,8 +2276,7 @@ function S45ROUND(state) {
 
     state.srPeriod = period;
 
-    switch (n & 0x30)
-    {
+    switch (n & 0x30) {
         case 0x00:
             state.srPhase = 0;
             break;
@@ -2294,11 +2292,11 @@ function S45ROUND(state) {
         default:
             throw new Error('invalid S45ROUND value');
     }
-        
+
     n &= 0x0F;
-    
-    if( n === 0 ) state.srThreshold = 0;
-    else state.srThreshold = (n/8 - 0.5) * period;
+
+    if (n === 0) state.srThreshold = 0;
+    else state.srThreshold = (n / 8 - 0.5) * period;
 }
 
 // ROFF[] Round Off
@@ -2344,11 +2342,10 @@ function SDPVTL(a, state) {
     var p2 = state.z2[p2i];
     var p1 = state.z1[p1i];
 
-    if (DEBUG) {
-        console.log( 'SDPVTL[' + a + ']', p2i, p1i );
-    }
+    if (DEBUG) console.log('SDPVTL[' + a + ']', p2i, p1i );
 
-    var dx, dy;
+    var dx;
+    var dy;
 
     if (!a) {
         dx = p1.x - p2.x;
@@ -2369,7 +2366,7 @@ function GETINFO(state) {
     var r = 0;
    
     if (DEBUG) console.log(state.step, 'GETINFO[]', sel);
-    
+
     // v35 as in no subpixel hinting
     if (sel & 0x01) r = 35;
 

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -1,0 +1,3123 @@
+/* A TrueType font hinting interpreter.
+*
+* (c) 2017 Axel Kittenberger
+*
+* This file is covered by the MIT (expat) License,
+* see the LICENSE file in the root of this project.
+*
+* This interpreter has been implemented according to this documentation:
+* https://developer.apple.com/fonts/TrueType-Reference-Manual/RM05/Chap5.html
+*
+* According to the documentation -- and thus most other implementations -- 
+* use F24DOT6 values for pixels. That means it's 1/64 pixel accurate and
+* use integer operations. However, Javascript has floating point operations
+* by default and only that's is available here. One could make a case to
+* simulate the 1/64 accuracy exactly by truncating after every division
+* operation (for example with << 0) to get pixel exacty results
+* as other TrueType implementations. It may make sense, since some fonts
+* are pixel optimized by hand using DELTAP instructions. The current
+* implementation doesn't and rather uses full floating point precission.
+*
+* xScale, yScale and rotation is currently ignored.
+*
+* A few non-trivial instructions are missing as I didn't encounter yet
+* a font that used them to test a possible implementation.
+*
+* Some fonts, seem to use undocumented features regarding the twilight zone.
+* Only some of them are implemented as encountered.
+*
+* The DEBUG statements can be removed, manually or for example with "uglify"
+* fixing DEBUG to false.
+*/
+'use strict';
+
+var DEBUG = false;
+
+var instructionTable;
+var exec, execComponent, execGlyph;
+
+/*
+* Creates a hinting object.
+*
+* There ought to be exactly one
+* for each truetype font that is used for hinting.
+*/
+function Hinting(font) {
+    // the font this hinting object is for
+    this.font = font;
+
+    // cached states
+    this._fpgmState  =
+    this._prepState  =
+        undefined;
+
+    // errorState
+    // 0 ... all okay
+    // 1 ... had an error in a glyf,
+    //       continue working but stop spamming
+    //       the console
+    // 2 ... error at prep, stop hinting at this ppem
+    // 3 ... error at fpeg, stop hinting for this font at all
+    this._errorState = 0;
+}
+
+
+/*
+* Not rounding.
+*/
+function roundOff(v) {
+    return v;
+}
+
+
+/*
+* Rounding to grid.
+*/
+function roundToGrid(v) {
+    //Rounding is in TT supposed to "symetrical around zero"
+    return Math.sign(v) * Math.round(Math.abs(v));
+}
+
+
+/*
+* Rounding to double grid.
+*/
+function roundToDoubleGrid(v) {
+    return Math.sign(v) * Math.round(Math.abs(v / 2)) * 2;
+}
+
+
+/*
+* Rounding to half grid.
+*/
+function roundToHalfGrid(v) {
+    return Math.sign(v) * Math.round(Math.abs(v * 2)) / 2;
+}
+
+
+/*
+* Rounding to up to grid.
+*/
+function roundUpToGrid(v) {
+    return Math.sign(v) * Math.ceil(Math.abs(v));
+}
+
+
+/*
+* Rounding to down to grid.
+*/
+function roundDownToGrid(v) {
+    return Math.sign(v) * Math.floor(Math.abs(v));
+}
+
+
+/*
+* Super rounding.
+*/
+var roundSuper = function(v) {
+    var period = this.srPeriod;
+    var phase = this.srPhase;
+    var threshold = this.srThreshold;
+    var sign = 1;
+
+    if (v < 0) { v = -v; sign = -1; }
+
+    v += phase;
+
+    var f = v % period;
+
+    if (f >= threshold) return Math.ceil(v) * sign - phase;
+    else return Math.floor(v) * sign - phase;
+};
+
+
+/*
+* Unit vector of x-axis.
+*/
+var xUnitVector = {
+    x : 1,
+
+    y : 0,
+
+    axis : 'x',
+
+    // Gets the projected distance between two points.
+    // o1/o2 ... if true, use respective original pos.
+    distance : function(p1, p2, o1, o2) {
+        return (o1 ? p1.xo : p1.x) - (o2 ? p2.xo : p2.x);
+    },
+
+    // Moves p so it has the moved position
+    // has the same relative position to the moved
+    // positions of rp1 and rp2 than the original
+    // positions had.
+    interpolate : function(p, rp1, rp2, pv) {
+        var do1, do2, doa1, doa2, dm1, dm2, dt;
+
+        if (!pv || pv === this) {
+            do1 = p.xo - rp1.xo;
+            do2 = p.xo - rp2.xo;
+            dm1 = rp1.x - rp1.xo;
+            dm2 = rp2.x - rp2.xo;
+            doa1 = Math.abs(do1);
+            doa2 = Math.abs(do2);
+            dt = doa1 + doa2;
+
+            if (dt === 0) {
+                p.x = p.xo + (dm1 + dm2) / 2;
+                return;
+            }
+
+            p.x = p.xo + (dm1 * doa2 + dm2 * doa1) / dt;
+            return;
+        }
+
+        do1 = pv.distance(p, rp1, true, true);
+        do2 = pv.distance(p, rp2, true, true);
+        dm1 = pv.distance(rp1, rp1, false, true);
+        dm2 = pv.distance(rp2, rp2, false, true);
+        doa1 = Math.abs(do1);
+        doa2 = Math.abs(do2);
+        dt = doa1 + doa2;
+
+        if (dt === 0) {
+            xUnitVector.setRelative(p, p, (dm1 + dm2) / 2, pv, true);
+            return;
+        }
+
+        xUnitVector.setRelative(p, p, (dm1 * doa2 + dm2 * doa1) / dt, pv, true);
+    },
+
+    // slope of line normal to this
+    normalSlope : Number.NEGATIVE_INFINITY,
+
+    // Sets the point 'p' relative to point 'rp'
+    // by the distance 'd'
+    // p   : point to set
+    // rp  : reference point
+    // d   : distance on projection vector
+    // pv  : projection vector (undefined = this)
+    // org : if true, use original position of rp as reference.
+    setRelative : function(p, rp, d, pv, org) {
+        if (!pv || pv === this) {
+            p.x = (org ? rp.xo : rp.x) + d;
+            return;
+        }
+
+        var rpx = org ? rp.xo : rp.x;
+        var rpy = org ? rp.yo : rp.y;
+        var rpdx = rpx + d * pv.x;
+        var rpdy = rpy + d * pv.y;
+
+        p.x = rpdx + ( p.y - rpdy ) / pv.normalSlope;
+    },
+
+    // slope of vector line
+    slope : 0,
+
+    // Touches the point p.
+    touch : function(p) { p.xTouched = true; },
+
+    // Tests if a point p is touched.
+    touched : function(p) { return p.xTouched; },
+
+    // Untouches the point p.
+    untouch : function(p) { p.xTouched = false; }
+};
+
+
+/*
+* Unit vector of y-axis.
+*/
+var yUnitVector = {
+    x : 0,
+
+    y : 1,
+
+    axis : 'y',
+
+    // Gets the projected distance between two points.
+    // o1/o2 ... if true, use respective original position.
+    distance : function(p1, p2, o1, o2) {
+        return (o1 ? p1.yo : p1.y) - (o2 ? p2.yo : p2.y);
+    },
+    
+    // Moves p so it has the moved position
+    // has the same relative position to the moved
+    // positions of rp1 and rp2 than the original
+    // positions had.
+    interpolate : function(p, rp1, rp2, pv) {
+        var do1, do2, doa1, doa2, dm1, dm2, dt;
+
+        if (!pv || pv === this) {
+            do1 = p.yo - rp1.yo;
+            do2 = p.yo - rp2.yo;
+            dm1 = rp1.y - rp1.yo;
+            dm2 = rp2.y - rp2.yo;
+            doa1 = Math.abs(do1);
+            doa2 = Math.abs(do2);
+            dt = doa1 + doa2;
+
+            if (dt === 0) {
+                p.y = p.yo + (dm1 + dm2) / 2;
+                return;
+            }
+
+            p.y = p.yo + (dm1 * doa2 + dm2 * doa1) / dt;
+            return;
+        }
+
+        do1 = pv.distance(p, rp1, true, true);
+        do2 = pv.distance(p, rp2, true, true);
+        dm1 = pv.distance(rp1, rp1, false, true);
+        dm2 = pv.distance(rp2, rp2, false, true);
+        doa1 = Math.abs(do1);
+        doa2 = Math.abs(do2);
+        dt = doa1 + doa2;
+
+        if (dt === 0) {
+            yUnitVector.setRelative(p, p, (dm1 + dm2) / 2, pv, true);
+            return;
+        }
+
+        yUnitVector.setRelative(p, p, (dm1 * doa2 + dm2 * doa1) / dt, pv, true);
+    },
+
+    // slope of line normal to this
+    normalSlope : 0,
+
+    // Sets the point 'p' relative to point 'rp'
+    // by the distance 'd'
+    // org ... if true, use original position of rp as reference.
+    setRelative : function(p, rp, d, pv, org) {
+        if (!pv || pv === this) {
+            p.y = (org ? rp.yo : rp.y) + d;
+            return;
+        }
+
+        var rpx = org ? rp.xo : rp.x;
+        var rpy = org ? rp.yo : rp.y;
+        var rpdx = rpx + d * pv.x;
+        var rpdy = rpy + d * pv.y;
+
+        p.y = rpdy + pv.normalSlope * (p.x - rpdx);
+    },
+
+    // slope of vector line
+    slope : Number.POSITIVE_INFINITY,
+
+    // Touches the point p.
+    touch : function(p) { p.yTouched = true; },
+
+    // Tests if a point p is touched.
+    touched : function(p) { return p.yTouched; },
+
+    // Untouches the point p.
+    untouch : function(p) { p.yTouched = false; }
+};
+
+
+Object.freeze(xUnitVector);
+Object.freeze(yUnitVector);
+
+
+/*
+* Creates a unit vector that is not x- or y-axis.
+*/
+function UnitVector(x, y) {
+    this.x = x;
+    this.y = y;
+    this.axis = undefined;
+    this.slope = y / x;
+    this.normalSlope = - x / y;
+    Object.freeze(this);
+}
+
+
+/*
+* Gets the projected distance between two points.
+* o1/o2 ... if true, use respective original pos.
+*/
+UnitVector.prototype.distance = function(p1, p2, o1, o2) {
+    return(
+        this.x * xUnitVector.distance(p1, p2, o1, o2) +
+        this.y * yUnitVector.distance(p1, p2, o1, o2)
+    );
+};
+
+    
+/*
+* Moves p so it has the moved position
+* has the same relative position to the moved
+* positions of rp1 and rp2 than the original
+* positions had.
+*/
+UnitVector.prototype.interpolate = function(p, rp1, rp2, pv) {
+    var dm1, dm2, do1, do2, doa1, doa2, dt;
+        
+    do1 = pv.distance(p, rp1, true, true);
+    do2 = pv.distance(p, rp2, true, true);
+    dm1 = pv.distance(rp1, rp1, false, true);
+    dm2 = pv.distance(rp2, rp2, false, true);
+    doa1 = Math.abs(do1);
+    doa2 = Math.abs(do2);
+    dt = doa1 + doa2;
+
+    if (dt === 0) {
+        this.setRelative(p, p, (dm1 + dm2) / 2, pv, true);
+        return;
+    }
+
+    this.setRelative(p, p, (dm1 * doa2 + dm2 * doa1 ) / dt, pv, true);
+};
+
+
+/*
+* Sets the point 'p' relative to point 'rp'
+* by the distance 'd'.
+* org ... if true, use original position of rp as reference
+*/
+UnitVector.prototype.setRelative = function(p, rp, d, pv, org) {
+    if (!pv) pv = this;
+
+    var rpx = org ? rp.xo : rp.x;
+    var rpy = org ? rp.yo : rp.y;
+    var rpdx = rpx + d * pv.x;
+    var rpdy = rpy + d * pv.y;
+
+    var pvns = pv.normalSlope;
+    var fvs = this.slope;
+
+    var px = p.x;
+    var py = p.y;
+
+    p.x = (fvs * px - pvns * rpdx + rpdy - py) / (fvs - pvns);
+    p.y = fvs * (p.x - px) + py;
+};
+
+
+/*
+* Touches the point p.
+*/
+UnitVector.prototype.touch = function(p) {
+    p.xTouched = true;
+    p.yTouched = true;
+};
+
+
+/*
+* Returns a unit vector with x/y coordinates.
+*/
+function getUnitVector(x, y) {
+    var d = Math.sqrt(x * x + y * y);
+
+    x /= d;
+    y /= d;
+
+    if( x === 1 && y === 0) return xUnitVector;
+    else if( x === 0 && y === 1) return yUnitVector;
+    else return new UnitVector(x, y);
+}
+
+
+/*
+* Creates a point in the hinting engine.
+*/
+function HPoint(
+    x,
+    y,
+    lastPointOfContour,
+    onCurve
+) {
+    // possibly may add rounding to 1/64 pixel here to behave exactly like
+    // other font engines...
+    this.x = this.xo = Math.round(x*64)/64; // hinted x value and original x-value
+    this.y = this.yo = Math.round(y*64)/64; // hinted y value and original y-value
+
+    this.lastPointOfContour = lastPointOfContour;
+    this.onCurve = onCurve;
+    this.prevPointOnContour = undefined;
+    this.nextPointOnContour = undefined;
+    this.xTouched = false;
+    this.yTouched = false;
+
+    Object.preventExtensions(this);
+}
+
+
+/*
+* Returns the next touched point on the contour.
+*/
+HPoint.prototype.nextTouched = function(v) {
+    var p = this.nextPointOnContour;
+
+    while (!v.touched(p) && p !== this) p = p.nextPointOnContour;
+
+    return p;
+};
+
+
+/*
+* Returns the previous touched point on the contour
+*/
+HPoint.prototype.prevTouched = function(v) {
+    var p = this.prevPointOnContour;
+
+    while (!v.touched(p) && p !== this) p = p.prevPointOnContour;
+
+    return p;
+};
+
+
+/*
+* The zero point.
+*/
+var HPZero = Object.freeze(new HPoint(0, 0));
+
+
+/*
+* The default state of the interpreter.
+*
+* Note: Freezing the defaultState and then deriving from it
+* makes the V8 Javascript engine going akward,
+* so this is avoided, albeit the defaultState shouldn't
+* ever change.
+*/
+var defaultState = {
+    cvCutIn : 17 / 16,    // control value cut in
+    deltaBase : 9,
+    deltaShift : 0.125,
+    loop : 1,             // loops some instructions
+    minDis : 1,           // minimum distance
+    autoFlip : true
+};
+
+
+/*
+* The current state of the interpreter.
+*
+* env  ... 'fpgm' or 'prep' or 'glyf'
+* prog ... the program
+*/
+function State(env, prog) {
+    this.env = env;
+    this.stack = [];
+    this.prog = prog;
+
+    switch(env) {
+        case 'glyf' :
+            this.zp0 = 1;
+            this.zp1 = 1;
+            this.zp2 = 1;
+            this.dpv = xUnitVector;
+            this.rp0 = this.rp1 = this.rp2 = 0;
+            /* fall through */
+        case 'prep' :
+            this.fv  = xUnitVector;
+            this.pv  = xUnitVector;
+            this.round = roundToGrid;
+    }
+}
+
+
+/*
+* Executes a glyph program.
+*
+* This does the hinting for each glyph.
+*
+* Returns an array of moved points.
+*
+* glyph: the glyph to hint
+* ppem: the size the glyph is rendered for
+*/
+Hinting.prototype.exec = function(glyph, ppem) {
+    if (typeof(ppem) !== 'number') {
+        throw new Error('Point size is not a number!');
+    }
+
+    // received a fatal error, don't do any hinting anymore
+    if (this._errorState > 2) return;
+
+    var font = this.font;
+    var prepState = this._prepState;
+
+    if(!prepState || prepState.ppem !== ppem) {
+        var fpgmState = this._fpgmState;
+
+        if (!fpgmState) {
+            // Executes the fpgm state.
+            // This is used by fonts to define functions
+            State.prototype = defaultState;
+
+            fpgmState =
+            this._fpgmState =
+                new State('fpgm', font.tables.fpgm);
+
+            fpgmState.funcs = [ ];
+            fpgmState.font = font;
+
+            if (DEBUG) {
+                console.log('---EXEC FPGM---');
+                fpgmState.step = -1;
+            }
+
+            try{
+                exec(fpgmState);
+            } catch(e) {
+                console.log('Hinting error in FPGM:' + e);
+                this._errorState = 3;
+                return;
+            }
+        }
+
+        // Executes the prep program for this ppem setting.
+        // This is used by fonts to set cvt values
+        // depending on to be rendered font size.
+
+        State.prototype = fpgmState;
+        prepState =
+        this._prepState =
+            new State('prep', font.tables.prep);
+
+        prepState.ppem = ppem;
+
+        // creates a copy of the cvt table
+        // and scales it to the current ppem setting
+        var oCvt = font.tables.cvt;
+        if (oCvt) {
+            var cvt = prepState.cvt = new Array(oCvt.length);
+            var scale = ppem / font.unitsPerEm;
+            for (var c = 0; c < oCvt.length; c++) {
+               cvt[c] = oCvt[c] * scale;
+            }
+        } else {
+            prepState.cvt = [];
+        }
+
+        if (DEBUG) {
+            console.log('---EXEC PREP---');
+            prepState.step = -1;
+        }
+
+        try{
+            exec(prepState);
+        } catch(e) {
+            if (this._errorState < 2) {
+                console.log('Hinting error in PREP:' + e);
+            }
+            this._errorState = 2;
+        }
+    }
+
+    if (this._errorState > 1) return;
+
+    try{
+        return execGlyph(glyph, prepState);
+    } catch(e) {
+        if (this._errorState < 1) {
+            console.log('Hinting error:' + e);
+            console.log('Note: further hinting errors are silenced');
+        }
+        this._errorState = 1;
+        return;
+    }
+};
+
+
+/*
+* Executes the hinting program for a glyph.
+*/
+function execGlyph(glyph, prepState) {
+    // original point positions
+    var xScale = prepState.ppem / prepState.font.unitsPerEm;
+    var yScale = xScale;
+    var components = glyph.components;
+    var contours;
+    var gZone;
+    var state;
+
+    State.prototype = prepState;
+    if (!components) {
+        state = new State('glyf', glyph.instructions);
+        if (DEBUG) {
+            console.log('---EXEC GLYPH---');
+            state.step = -1;
+        }
+        execComponent(glyph, state, xScale, yScale);
+        gZone = state.gZone;
+    } else {
+        var font = prepState.font;
+        gZone = [];
+        contours = [];
+        for(var i = 0; i < components.length; i++) {
+            var c = components[i];
+            var cg = font.glyphs.get(c.glyphIndex);
+
+            state = new State('glyf', cg.instructions);
+
+            if (DEBUG) {
+                console.log('---EXEC COMP ' + i + '---');
+                state.step = -1;
+            }
+
+            execComponent(cg, state, xScale, yScale);
+            // appends the computed points to the result array
+            // post processes the component points
+            var dx = Math.round(c.dx * xScale);
+            var dy = Math.round(c.dy * yScale);
+            var gz = state.gZone;
+            var cc = state.contours;
+            for(var pi = 0; pi < gz.length; pi++) {
+                var p = gz[pi];
+                p.xTouched = p.yTouched = false;
+                p.xo = p.x = p.x + dx;
+                p.yo = p.y = p.y + dy;
+            }
+
+            var gLen = gZone.length;
+            gZone.push.apply(gZone, gz);
+            for(var j = 0; j < cc.length; j++) {
+                contours.push(cc[j] + gLen);
+            }
+        }
+
+        if (glyph.instructions && !state.inhibitGridFit) {
+            // the composite has instructions on its own
+            state = new State('glyf', glyph.instructions);
+
+            state.gZone = state.z0 = state.z1 = state.z2 = gZone;
+
+            state.contours = contours;
+
+            // note: HPZero cannot be used here, since
+            //       the point might be modified
+            gZone.push(
+                new HPoint(0, 0),
+                new HPoint(Math.round(glyph.advanceWidth * xScale), 0)
+            );
+
+            if (DEBUG) {
+                console.log('---EXEC COMPOSITE---');
+                state.step = -1;
+            }
+
+            exec(state);
+
+            gZone.length -= 2;
+        }
+    }
+    
+    return gZone;
+}
+
+
+/*
+* Executes the hinting program for a componenet of a multi-component glyph
+* Or of the glyph itself by a non-component glyph
+*/
+function execComponent(glyph, state, xScale, yScale)
+{
+    var points = glyph.points || [];
+    var pLen = points.length;
+    var gZone = state.gZone = state.z0 = state.z1 = state.z2 = [];
+    var contours = state.contours = [];
+    var i;
+
+    // scales the original points and
+    // makes copies for the hinted points
+    var cp; // current point
+    for (i = 0; i < pLen; i++) {
+        cp = points[i];
+
+        gZone[i] = new HPoint(
+            cp.x * xScale,
+            cp.y * yScale,
+            cp.lastPointOfContour,
+            cp.onCurve
+        );
+    }
+    
+    // loops again to chain link the contours
+    var sp; // start point
+    var np; // next point
+
+    for (i = 0; i < pLen; i++) {
+        cp = gZone[i];
+
+        if (!sp) {
+            sp = cp;
+            contours.push(i);
+        }
+
+        if (cp.lastPointOfContour) {
+            cp.nextPointOnContour = sp;
+            sp.prevPointOnContour = cp;
+            sp = undefined;
+        } else {
+            np = gZone[i + 1];
+            cp.nextPointOnContour = np;
+            np.prevPointOnContour = cp;
+        }
+    }
+
+    if (state.inhibitGridFit) return;
+
+    gZone.push(
+        new HPoint(0, 0),
+        new HPoint(Math.round(glyph.advanceWidth * xScale), 0)
+    );
+
+    exec(state);
+
+    // removes the extra points
+    gZone.length -= 2;
+
+    if (DEBUG) {
+        console.log('FINISHED GLYPH', state.stack);
+        for (i = 0; i < pLen; i++) {
+            console.log(i, gZone[i].x, gZone[i].y);
+        }
+    }
+}
+
+
+/*
+* Executes the program loaded in state.
+*/
+function exec(state) {
+    var prog = state.prog;
+
+    if (!prog) return;
+
+    var pLen = prog.length;
+    var ins;
+
+    for(state.ip = 0; state.ip < pLen; state.ip++) {
+        if (DEBUG) state.step++;
+        ins = instructionTable[prog[state.ip]];
+        
+        if(!ins) {
+            throw new Error(
+                'unknown instruction: 0x' +
+                Number(prog[state.ip]).toString(16)
+            );
+        }
+       
+        ins(state);
+        
+        // very extensive debugging for each step
+        /*
+        if (DEBUG) {
+            var da, i;
+            if (state.gZone) {
+                da = [];
+                for(i = 0; i < state.gZone.length; i++)
+                {
+                    da.push(i + ' ' +
+                        state.gZone[i].x * 64 + ' ' +
+                        state.gZone[i].y * 64 + ' ' +
+                        (state.gZone[i].xTouched ? 'x' : '') +
+                        (state.gZone[i].yTouched ? 'y' : '')
+                    );
+                }
+                console.log('GZ', da);
+            }
+            
+            if (state.tZone) {
+                da = [];
+                for(i = 0; i < state.tZone.length; i++)
+                {
+                    da.push(i + ' ' +
+                        state.tZone[i].x * 64 + ' ' +
+                        state.tZone[i].y * 64 + ' ' +
+                        (state.tZone[i].xTouched ? 'x' : '') +
+                        (state.tZone[i].yTouched ? 'y' : '')
+                    );
+                }
+                console.log('TZ', da);
+            }
+
+            if (state.stack.length > 10) {
+                console.log(
+                    state.stack.length,
+                    '...', state.stack.slice(state.stack.length - 10)
+                );
+            } else {
+                console.log(state.stack.length, state.stack);
+            }
+        }
+        */
+    }
+}
+                
+
+/*
+* Initializes the twilight zone.
+* This is only done if a SZPx instruction
+* refers to the twilight zone.
+*/
+function initTZone(state)
+{
+    var tZone = state.tZone = new Array(state.gZone.length);
+
+    // no idea if this is actually correct...
+    for(var i = 0; i < tZone.length; i++)
+    {
+        tZone[i] = new HPoint(0, 0);
+    }
+}
+
+/*----------------------------------------------------------*
+*          And then a lot of instructions...                *
+*----------------------------------------------------------*/
+
+
+// SVTCA[a] Set freedom and projection Vectors To Coordinate Axis
+// 0x00-0x01
+function SVTCA(v, state) {
+    if (DEBUG) console.log(state.step, 'SVTCA[' + v.axis + ']');
+
+    state.fv = state.pv = state.dpv = v;
+}
+
+// SPVTCA[a] Set Projection Vector to Coordinate Axis
+// 0x02-0x03
+function SPVTCA(v, state) {
+    if (DEBUG) console.log(state.step, 'SPVTCA[' + v.axis + ']');
+
+    state.pv = state.dpv = v;
+}
+
+
+// SFVTCA[a] Set Freedom Vector to Coordinate Axis
+// 0x04-0x05
+function SFVTCA(v, state) {
+    if (DEBUG) console.log(state.step, 'SFVTCA[' + v.axis + ']');
+
+    state.fv = v;
+}
+
+
+// SPVTL[a] Set Projection Vector To Line
+// 0x06-0x07
+function SPVTL(a, state) {
+    var stack = state.stack;
+    var p2i = stack.pop();
+    var p1i = stack.pop();
+    var p2 = state.z2[p2i];
+    var p1 = state.z1[p1i];
+
+    if (DEBUG) console.log( 'SPVTL[' + a + ']', p2i, p1i );
+
+    var dx, dy;
+
+    if (!a) {
+        dx = p1.x - p2.x;
+        dy = p1.y - p2.y;
+    } else {
+        dx = p2.y - p1.y;
+        dy = p1.x - p2.x;
+    }
+
+    state.pv = state.dpv = getUnitVector(dx, dy);
+}
+
+
+// SFVTL[a] Set Freedom Vector To Line
+// 0x08-0x09
+function SFVTL(a, state) {
+    var stack = state.stack;
+    var p2i = stack.pop();
+    var p1i = stack.pop();
+    var p2 = state.z2[p2i];
+    var p1 = state.z1[p1i];
+
+    if (DEBUG) console.log( 'SFVTL[' + a + ']', p2i, p1i );
+
+    var dx, dy;
+
+    if (!a) {
+        dx = p1.x - p2.x;
+        dy = p1.y - p2.y;
+    } else {
+        dx = p2.y - p1.y;
+        dy = p1.x - p2.x;
+    }
+
+    state.fv = getUnitVector(dx, dy);
+}
+
+
+// SPVFS[] Set Projection Vector From Stack
+// 0x0A
+function SPVFS(state) {
+    var stack = state.stack;
+    var y = stack.pop();
+    var x = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SPVFS[]', y, x);
+
+    state.pv = state.dpv = getUnitVector(x, y);
+}
+
+
+// SFVFS[] Set Freedom Vector From Stack
+// 0x0B
+function SFVFS(state) {
+    var stack = state.stack;
+    var y = stack.pop();
+    var x = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SPVFS[]', y, x);
+
+    state.fv = getUnitVector(x, y);
+}
+
+
+// GPV[] Get Projection Vector
+// 0x0C
+function GPV(state) {
+    var stack = state.stack;
+    var pv = state.pv;
+
+    if (DEBUG) console.log(state.step, 'GPV[]');
+
+    stack.push(pv.x * 0x4000);
+    stack.push(pv.y * 0x4000);
+}
+
+
+// GFV[] Get Freedom Vector
+// 0x0C
+function GFV(state) {
+    var stack = state.stack;
+    var fv = state.fv;
+
+    if (DEBUG) console.log(state.step, 'GFV[]');
+
+    stack.push(fv.x * 0x4000);
+    stack.push(fv.y * 0x4000);
+}
+
+
+// SFVTPV[] Set Freedom Vector To Projection Vector
+// 0x0E
+function SFVTPV(state) {
+    state.fv = state.pv;
+
+    if (DEBUG) console.log(state.step, 'SFVTPV[]');
+}
+
+
+// ISECT[] moves point p to the InterSECTion of two lines
+// 0x0F
+function ISECT(state)
+{
+    var stack = state.stack;
+    var pa0i = stack.pop();
+    var pa1i = stack.pop();
+    var pb0i = stack.pop();
+    var pb1i = stack.pop();
+    var pi = stack.pop();
+    var z0 = state.z0;
+    var z1 = state.z1;
+    var pa0 = z0[pa0i];
+    var pa1 = z0[pa1i];
+    var pb0 = z1[pb0i];
+    var pb1 = z1[pb1i];
+    var p = state.z2[pi];
+    
+    if (DEBUG) {
+        console.log(
+            'ISECT[], ',
+            pa0i,
+            pa1i,
+            pb0i,
+            pb1i,
+            pi
+        );
+    }
+
+    // math from
+    // en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line
+
+    var x1 = pa0.x;
+    var y1 = pa0.y;
+    var x2 = pa1.x;
+    var y2 = pa1.y;
+    var x3 = pb0.x;
+    var y3 = pb0.y;
+    var x4 = pb1.x;
+    var y4 = pb1.y;
+
+    var div = (x1 - x2)*(y3 - y4) - (y1 - y2)*(x3 - x4);
+    var f1 = x1*y2 - y1*x2;
+    var f2 = x3*y4 - y3*x4; 
+
+    p.x = (f1*(x3 - x4) - f2*(x1 - x2)) / div;
+
+    p.y = (f1*(y3 - y4) - f2*(y1 - y2)) / div;
+}
+
+
+// SRP0[] Set Reference Point 0
+// 0x10
+function SRP0(state) {
+    state.rp0 = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SRP0[]', state.rp0);
+}
+
+
+// SRP1[] Set Reference Point 1
+// 0x11
+function SRP1(state) {
+    state.rp1 = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SRP1[]', state.rp1);
+}
+
+
+// SRP1[] Set Reference Point 2
+// 0x12
+function SRP2(state) {
+    state.rp2 = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SRP2[]', state.rp2);
+}
+
+
+// SZP0[] Set Zone Pointer 0
+// 0x13
+function SZP0(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SZP0[]', n);
+ 
+    state.zp0 = n;
+
+    switch(n) {
+        case 0:
+            if (!state.tZone) initTZone(state);
+            state.z0 = state.tZone;
+            break;
+        case 1 :
+            state.z0 = state.gZone;
+            break;
+        default :
+            throw new Error('Invalid zone pointer');
+    }
+}
+
+
+// SZP1[] Set Zone Pointer 1
+// 0x14
+function SZP1(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SZP1[]', n);
+ 
+    state.zp1 = n;
+
+    switch(n) {
+        case 0:
+            if (!state.tZone) initTZone(state);
+            state.z1 = state.tZone;
+            break;
+        case 1 :
+            state.z1 = state.gZone;
+            break;
+        default :
+            throw new Error('Invalid zone pointer');
+    }
+}
+
+
+// SZP2[] Set Zone Pointer 2
+// 0x15
+function SZP2(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SZP2[]', n);
+ 
+    state.zp2 = n;
+
+    switch(n) {
+        case 0:
+            if (!state.tZone) initTZone(state);
+            state.z2 = state.tZone;
+            break;
+        case 1 :
+            state.z2 = state.gZone;
+            break;
+        default :
+            throw new Error('Invalid zone pointer');
+    }
+}
+
+
+// SZPS[] Set Zone PointerS
+// 0x16
+function SZPS(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SZPS[]', n);
+ 
+    state.zp0 = state.zp1 = state.zp2 = n;
+
+    switch(n) {
+        case 0:
+            if (!state.tZone) initTZone(state);
+            state.z0 = state.z1 = state.z2 = state.tZone;
+            break;
+        case 1 :
+            state.z0 = state.z1 = state.z2 = state.gZone;
+            break;
+        default :
+            throw new Error('Invalid zone pointer');
+    }
+}
+
+
+// SLOOP[] Set LOOP variable
+// 0x17
+function SLOOP(state) {
+    state.loop = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SLOOP[]', state.loop);
+}
+
+
+// RTG[] Round To Grid
+// 0x18
+function RTG(state) {
+    if (DEBUG) console.log(state.step, 'RTG[]');
+
+    state.round = roundToGrid;
+}
+
+
+// RTHG[] Round To Half Grid
+// 0x19
+function RTHG(state) {
+    if (DEBUG) console.log(state.step, 'RTHG[]');
+
+    state.round = roundToHalfGrid;
+}
+
+
+// SMD[] Set Minimum Distance
+// 0x1A
+function SMD(state) {
+    var d = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SMD[]', d);
+    
+    state.minDis = d / 0x40;
+}
+
+
+// ELSE[] ELSE clause
+// 0x1B
+function ELSE(state) {
+    // this instruction has been reached by executing a then branch
+    // so it just skips ahead until mathing EIF
+    var ip = state.ip;
+    var prog = state.prog;
+
+    if (DEBUG) console.log(state.step, 'ELSE[]');
+
+    // otherwise skip forward until matching else or endif
+    var nesting = 1;
+    var ins;
+    do{
+        ins = prog[++ip];
+        switch(ins) {
+            case 0x59: // EIF
+                nesting--;
+                break;
+            case 0x58: // IF
+                nesting++;
+                break;
+        }
+    } while(nesting > 0);
+
+    state.ip = ip;
+}
+
+
+// JMPR[] JuMP Relative
+// 0x1C
+function JMPR(state) {
+    var o = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'JMPR[]', o);
+
+    // A jump by 1 would do nothing
+
+    state.ip += o - 1;
+}
+
+// SCVTCI[] Set Control Value Table Cut-In
+// 0x1D
+function SCVTCI(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SCVTCI[]', n);
+
+    state.cvCutIn = n / 0x40;
+}
+
+
+// DUP[] DUPlicate top stack element
+// 0x20
+function DUP(state) {
+    var stack = state.stack;
+
+    if (DEBUG) console.log(state.step, 'DUP[]');
+
+    stack.push(stack[stack.length - 1]);
+}
+
+
+// POP[] POP top stack element
+// 0x21
+function POP(state) {
+    if (DEBUG) console.log(state.step, 'POP[]');
+
+    state.stack.pop();
+}
+
+
+// CLEAR[] CLEAR the stack
+// 0x22
+function CLEAR(state) {
+    if (DEBUG) console.log(state.step, 'CLEAR[]');
+
+    state.stack.length = 0;
+}
+
+
+// SWAP[] SWAP the top two elements on the stack
+// 0x23
+function SWAP(state) {
+    var stack = state.stack;
+
+    var a = stack.pop();
+    var b = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SWAP[]');
+
+    stack.push(a);
+    stack.push(b);
+}
+
+
+// DEPTH[] DEPTH of the stack
+// 0x24
+function DEPTH(state) {
+    var stack = state.stack;
+
+    if (DEBUG) console.log(state.step, 'DEPTH[]');
+
+    stack.push( stack.length );
+}
+
+
+// LOOPCALL[] LOOPCALL function
+// 0x2A
+function LOOPCALL(state) {
+    var stack = state.stack;
+    var fn = stack.pop();
+    var c = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'LOOPCALL[]', fn, c);
+
+    // saves callers program
+    var cip = state.ip;
+    var cprog = state.prog;
+
+    state.prog = state.funcs[fn];
+
+    // executes the function
+    for(var i = 0; i < c; i++) {
+        exec(state);
+
+        if (DEBUG) console.log(
+            ++state.step,
+            i + 1 < c ? 'next loopcall' : 'done loopcall',
+            i
+        );
+    }
+
+    // restores the callers program
+    state.ip = cip;
+    state.prog = cprog;
+}
+
+// CALL[] CALL function
+// 0x2B
+function CALL(state) {
+    var fn = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'CALL[]', fn);
+
+    // saves callers program
+    var cip = state.ip;
+    var cprog = state.prog;
+
+    state.prog = state.funcs[fn];
+
+    // executes the function
+    exec(state);
+
+    // restores the callers program
+    state.ip = cip;
+    state.prog = cprog;
+
+    if (DEBUG) console.log(++state.step, 'returning from', fn);
+}
+
+
+// CINDEX[] Copy the INDEXed element to the top of the stack
+// 0x25
+function CINDEX(state) {
+    var stack = state.stack;
+    var k = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'CINDEX[]', k);
+
+    stack.push(stack[stack.length - k]);
+
+    // In case of k == 1, it copies the last element after poping
+    // thus stack.length - k.
+}
+
+
+// MINDEX[] Move the INDEXed element to the top of the stack
+// 0x26
+function MINDEX(state) {
+    var stack = state.stack;
+    var k = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'MINDEX[]', k);
+
+    stack.push(stack.splice(stack.length - k, 1)[ 0 ]);
+}
+
+
+// FDEF[] Function DEFinition
+// 0x2C
+function FDEF(state) {
+    if (state.env !== 'fpgm') throw new Error('FDEF not allowed here');
+    var stack = state.stack;
+    var prog = state.prog;
+    var ip = state.ip;
+
+    var fn = stack.pop();
+    var ipBegin = ip;
+
+    if (DEBUG) console.log(state.step, 'FDEF[]', fn);
+
+    while (prog[++ip] !== 0x2D);
+
+    state.ip = ip;
+    state.funcs[fn] = prog.slice(ipBegin + 1, ip);
+}
+
+
+// MDAP[a] Move Direct Absolute Point
+// 0x2E-0x2F
+function MDAP(round, state) {
+    var pi = state.stack.pop();
+    var p = state.z0[pi];
+    var fv = state.fv;
+    var pv = state.pv;
+    
+    if (DEBUG) console.log(state.step, 'MDAP[' + round + ']', pi);
+
+    var d = pv.distance(p, HPZero);
+
+    if (round) d = state.round(d);
+
+    fv.setRelative(p, HPZero, d, pv);
+    fv.touch(p);
+
+    state.rp0 = state.rp1 = pi;
+}
+
+
+// IUP[a] Interpolate Untouched Points through the outline
+// 0x30
+function IUP(v, state) {
+    var z2 = state.z2;
+    var pLen = z2.length - 2;
+    var cp;
+    var pp, np;
+
+    if (DEBUG) console.log(state.step, 'IUP[' + v.axis + ']');
+
+    for (var i = 0; i < pLen; i++) {
+        cp = z2[i]; // current point
+
+        // if this point has been touched go on
+        if (v.touched(cp)) continue;
+    
+        pp = cp.prevTouched(v);
+
+        // no point on the contour has been touched?
+        if (pp === cp) continue;
+
+        np = cp.nextTouched(v);
+
+        if (pp === np) {
+            // only one point on the contour has been touched
+            // so simply moves the point like that
+
+            v.setRelative(cp, cp, v.distance(pp, pp, false, true), v, true);
+        }
+
+        v.interpolate(cp, pp, np, v);
+    }
+}
+
+
+// SHP[] SHift Point using reference point
+// 0x32-0x33
+function SHP(a, state) {
+    var stack = state.stack;
+    var rpi = a ? state.rp1 : state.rp2;
+    var rp = (a ? state.z0 : state.z1)[rpi];
+    var fv = state.fv;
+    var pv = state.pv;
+    var loop = state.loop;
+    var z2 = state.z2;
+
+    while (loop--)
+    {
+        var pi = stack.pop();
+        var p = z2[pi];
+
+        var d = pv.distance(rp, rp, false, true);
+        fv.setRelative(p, p, d, pv);
+        fv.touch(p);
+
+        if (DEBUG) {
+            console.log(
+                state.step,
+                (  state.loop > 1 ? 
+                   'loop ' + (state.loop - loop) + ': ' :
+                   ''
+                ) +
+                'SHP[' + (a ? 'rp1' : 'rp2') + ']', pi
+            );
+        }
+    }
+
+    state.loop = 1;
+}
+
+
+// SHC[] SHift Contour using reference point
+// 0x36-0x37
+function SHC(a, state) {
+    var stack = state.stack;
+    var rpi = a ? state.rp1 : state.rp2;
+    var rp = (a ? state.z0 : state.z1)[rpi];
+    var fv = state.fv;
+    var pv = state.pv;
+    var ci = stack.pop();
+    var sp = state.z2[state.contours[ci]];
+    var p = sp;
+
+    if (DEBUG) console.log(state.step, 'SHC[' + a + ']', ci);
+
+    var d = pv.distance(rp, rp, false, true);
+
+    do{
+        if (p !== rp) fv.setRelative(p, p, d, pv);
+        p = p.nextPointOnContour;
+    } while(p !== sp);
+}
+
+
+// SHZ[] SHift Zone using reference point
+// 0x36-0x37
+function SHZ(a, state) {
+    var stack = state.stack;
+    var rpi = a ? state.rp1 : state.rp2;
+    var rp = (a ? state.z0 : state.z1)[rpi];
+    var fv = state.fv;
+    var pv = state.pv;
+
+    var e = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SHZ[' + a + ']', e);
+
+    var z;
+    switch(e) {
+        case 0 : z = state.tZone; break;
+        case 1 : z = state.gZone; break;
+        default : throw new Error('Invalid zone');
+    }
+    
+    var p;
+    var d = pv.distance(rp, rp, false, true);
+    var pLen = z.length - 2;
+    for (var i = 0; i < pLen; i++)
+    {
+        p = z[i];
+        if (p !== rp) fv.setRelative(p, p, d, pv);
+    }
+}
+
+
+// SHPIX[] SHift point by a PIXel amount
+// 0x38
+function SHPIX(state) {
+    var stack = state.stack;
+    var loop = state.loop;
+    var fv = state.fv;
+    var d = stack.pop() / 0x40;
+    var z2 = state.z2;
+
+    while (loop--) {
+        var pi = stack.pop();
+        var p = z2[pi];
+
+        if (DEBUG) console.log(
+            state.step,
+            (state.loop > 1 ? 'loop ' + (state.loop - loop) + ': ' : '') +
+            'SHPIX[]', pi, d
+        );
+
+        fv.setRelative(p, p, d);
+        fv.touch(p);
+    }
+
+    state.loop = 1;
+}
+
+
+// IP[] Interpolate Point
+// 0x39
+function IP(state) {
+    var stack = state.stack;
+    var rp1i = state.rp1;
+    var rp2i = state.rp2;
+    var loop = state.loop;
+    var rp1 = state.z0[rp1i];
+    var rp2 = state.z1[rp2i];
+    var fv = state.fv;
+    var pv = state.dpv;
+    var z2 = state.z2;
+    
+    while (loop--) {
+        var pi = stack.pop();
+        var p = z2[pi];
+
+        if (DEBUG) console.log(
+            state.step,
+            (state.loop > 1 ? 'loop ' + (state.loop - loop) + ': ' : '') +
+            'IP[]', pi, rp1i, '<->', rp2i
+        );
+
+        fv.interpolate(p, rp1, rp2, pv);
+
+        fv.touch(p);
+    }
+
+    state.loop = 1;
+}
+
+
+// MSIRP[a] Move Stack Indirect Relative Point
+// 0x3A-0x3B
+function MSIRP(a, state) {
+    var stack = state.stack;
+    var d = stack.pop() / 64;
+    var pi = stack.pop();
+    var p = state.z1[pi];
+    var rp0 = state.z0[state.rp0];
+    var fv = state.fv;
+    var pv = state.pv;
+    
+    fv.setRelative(p, rp0, d, pv);
+    fv.touch(p);
+
+    if (DEBUG) console.log(state.step, 'MSIRP[' + a + ']', d, pi);
+
+    state.rp1 = state.rp0;
+    state.rp2 = pi;
+    if (a) state.rp0 = pi;
+}
+
+
+
+// ALIGNRP[] Align to reference point.
+// 0x3C
+function ALIGNRP(state) {
+    var stack = state.stack;
+    var rp0i = state.rp0;
+    var rp0 = state.z0[rp0i];
+    var loop = state.loop;
+    var fv = state.fv;
+    var pv = state.pv;
+    var z1 = state.z1;
+
+    while (loop--) {
+        var pi = stack.pop();
+        var p = z1[ pi ];
+
+        if (DEBUG) console.log(
+            state.step,
+            (state.loop > 1 ? 'loop ' + (state.loop - loop) + ': ' : '') +
+            'ALIGNRP[]', pi
+        );
+
+        fv.setRelative(p, rp0, 0, pv);
+        fv.touch(p);
+    }
+
+    state.loop = 1;
+}
+
+
+// RTG[] Round To Double Grid
+// 0x3D
+function RTDG(state) {
+    if (DEBUG) console.log(state.step, 'RTDG[]');
+
+    state.round = roundToDoubleGrid;
+}
+
+
+// MIAP[a] Move Indirect Absolute Point
+// 0x3E-0x3F
+function MIAP(round, state) {
+    var stack = state.stack;
+    var n = stack.pop();
+    var pi = stack.pop();
+    var p = state.z0[pi];
+    var fv = state.fv;
+    var pv = state.pv;
+    var cv = state.cvt[n];
+
+    // TODO cvtcutin should be considered here
+
+    if (round) cv = state.round(cv);
+   
+    if (DEBUG) {
+        console.log(
+            state.step,
+            'MIAP[' + round + ']',
+            n, '(', cv, ')', pi
+        );
+    }
+
+    fv.setRelative(p, HPZero, cv, pv);
+
+    if (state.zp0 === 0) {
+        p.xo = p.x;
+        p.yo = p.y;
+    }
+
+    fv.touch(p);
+
+    state.rp0 = state.rp1 = pi;
+}
+
+
+// NPUSB[] PUSH N Bytes
+// 0x40
+function NPUSHB(state) {
+    var prog = state.prog;
+    var ip = state.ip;
+    var stack = state.stack;
+
+    var n = prog[++ip];
+
+    if (DEBUG) console.log(state.step, 'NPUSHB[]', n);
+
+    for (var i = 0; i < n; i++) stack.push(prog[++ip]);
+
+    state.ip = ip;
+}
+
+
+// NPUSHW[] PUSH N Words
+// 0x41
+function NPUSHW(state) {
+    var ip = state.ip;
+    var prog = state.prog;
+    var stack = state.stack;
+    var n = prog[++ip];
+
+    if (DEBUG) console.log(state.step, 'NPUSHW[]', n);
+
+    for (var i = 0; i < n; i++) {
+        var w = (prog[++ip] << 8) | prog[++ip];
+        if (w & 0x8000) w = -((w^0xffff)+1);
+        stack.push(w);
+    }
+    
+    state.ip = ip;
+}
+
+
+// WS[] Write Store
+// 0x42
+function WS(state) {
+    var stack = state.stack;
+    var store = state.store;
+
+    if (!store) store = state.store = [];
+
+    var v = stack.pop();
+    var l = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'WS', v, l);
+
+    store[l] = v;
+}
+
+
+// RS[] Read Store
+// 0x43
+function RS(state) {
+    var stack = state.stack;
+    var store = state.store;
+
+    var l = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'RS', l);
+
+    var v = (store && store[l]) || 0;
+
+    stack.push(v);
+}
+
+
+// WCVTP[] Write Control Value Table in Pixel units
+// 0x44
+function WCVTP(state) {
+    var stack = state.stack;
+
+    var v = stack.pop();
+    var l = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'WCVTP', v, l);
+
+    state.cvt[l] = v / 0x40;
+}
+
+
+// RCVT[] Read Control Value Table entry
+// 0x45
+function RCVT(state) {
+    var stack = state.stack;
+    var cvte = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'RCVT', cvte);
+
+    stack.push(state.cvt[cvte] * 0x40);
+}
+
+
+// GC[] Get Coordinate projected onto the projection vector
+// 0x46-0x47
+function GC(a, state) {
+    var stack = state.stack;
+    var pi = stack.pop();
+    var p = state.z2[pi];
+
+    if (DEBUG) console.log(state.step, 'GC[' + a + ']', pi);
+
+    var d = state.dpv.distance(p, HPZero, a, false);
+    stack.push(d * 0x40);
+}
+
+
+// MD[a] Measure Distance
+// 0x49-0x4A
+function MD(a, state) {
+    var stack = state.stack;
+    var pi2 = stack.pop();
+    var pi1 = stack.pop();
+    var p2 = state.z1[pi2];
+    var p1 = state.z0[pi1];
+    var d = state.dpv.distance(p1, p2, a, a);
+
+    if (DEBUG) console.log(state.step, 'MD[' + a + ']', pi2, pi1, '->', d);
+
+    state.stack.push(Math.round(d * 64));
+}
+
+
+// MPPEM[] Measure Pixels Per EM
+// 0x4B
+function MPPEM(state) {
+    if (DEBUG) console.log(state.step, 'MPPEM[]');
+    state.stack.push(state.ppem);
+}
+
+
+// FLIPON[] set the auto FLIP Boolean to ON
+// 0x4D
+function FLIPON(state) {
+    if (DEBUG) console.log(state.step, 'FLIPON[]');
+    state.autoFlip = true;
+}
+
+
+// LT[] Less Than
+// 0x50
+function LT(state) {
+    var stack = state.stack;
+
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'LT[]', e2, e1);
+
+    stack.push(e1 < e2 ? 1 : 0);
+}
+
+
+// LTEQ[] Less Than or EQual
+// 0x53
+function LTEQ(state) {
+    var stack = state.stack;
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+    
+    if (DEBUG) console.log(state.step, 'LTEQ[]', e2, e1);
+
+    stack.push(e1 <= e2 ? 1 : 0);
+}
+
+
+// GTEQ[] Greater Than
+// 0x52
+function GT(state) {
+    var stack = state.stack;
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'GT[]', e2, e1);
+
+    stack.push(e1 > e2 ? 1 : 0);
+}
+
+
+// GTEQ[] Greater Than or EQual
+// 0x53
+function GTEQ(state) {
+    var stack = state.stack;
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+    
+    if (DEBUG) console.log(state.step, 'GTEQ[]', e2, e1);
+
+    stack.push(e1 >= e2 ? 1 : 0);
+}
+
+
+// EQ[] EQual
+// 0x54
+function EQ(state) {
+    var stack = state.stack;
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'EQ[]', e2, e1);
+    
+    stack.push(e2 === e1 ? 1 : 0);
+}
+
+
+// NEQ[] Not EQual
+// 0x55
+function NEQ(state) {
+    var stack = state.stack;
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'NEQ[]', e2, e1);
+    
+    stack.push(e2 !== e1 ? 1 : 0);
+}
+
+
+// ODD[] ODD
+// 0x56
+function ODD(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'ODD[]', n);
+
+    stack.push(Math.trunc(n) % 2 ? 1 : 0);
+}
+
+
+// EVEN[] EVEN
+// 0x57
+function EVEN(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'EVEN[]', n);
+
+    stack.push(Math.trunc(n) % 2 ? 0 : 1);
+}
+
+
+// IF[] IF test
+// 0x58
+function IF(state) {
+    var ip = state.ip;
+    var prog = state.prog;
+
+    var test = state.stack.pop();
+    var ins;
+    
+    if (DEBUG) console.log(state.step, 'IF[]', test);
+
+    // if test is true it just continues
+    // if not the ip is skiped until matching ELSE or EIF
+    if (!test)
+    {
+        // otherwise skip forward until matching else or endif
+        var nesting = 1;
+        do{
+            ins = prog[++ip];
+            switch(ins) {
+                case 0x1B: // ELSE
+                    if (nesting === 1) nesting--;
+                    break;
+                case 0x59: // EIF
+                    nesting--;
+                    break;
+                case 0x58: // IF
+                    nesting++;
+                    break;
+            }
+        } while(nesting > 0);
+    
+        if (DEBUG) console.log(state.step, ins === 0x1B ? 'ELSE[]' : 'EIF[]');
+    }
+
+    state.ip = ip;
+}
+
+
+// EIF[] End IF
+// 0x59
+function EIF(state) {
+    // this can be reached normally when
+    // executing an else branch.
+    // -> just ignore it
+    
+    if (DEBUG) console.log(state.step, 'EIF[]');
+}
+
+
+// AND[] logical AND
+// 0x5A
+function AND(state) {
+    var stack = state.stack;
+
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'AND[]', e2, e1);
+
+    stack.push(e2 && e1 ? 1 : 0);
+}
+
+
+// OR[] logical OR
+// 0x5B
+function OR(state) {
+    var stack = state.stack;
+
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'OR[]', e2, e1);
+
+    stack.push(e2 || e1 ? 1 : 0);
+}
+
+
+// NOT[] logical NOT
+// 0x5C
+function NOT(state) {
+    var stack = state.stack;
+
+    var e = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'NOT[]', e);
+
+    stack.push(e ? 0 : 1);
+}
+
+
+// DELTAP1[] DELTA exception P1
+// DELTAP2[] DELTA exception P2
+// DELTAP3[] DELTA exception P3
+// 0x5D, 0x71, 0x72
+function DELTAP123(b, state) {
+    var stack = state.stack;
+    var n = stack.pop();
+    var fv = state.fv;
+    var pv = state.pv;
+    var ppem = state.ppem;
+    var base = state.deltaBase + (b - 1) * 16;
+    var ds = state.deltaShift;
+    var z0 = state.z0;
+    
+    if (DEBUG) console.log(state.step, 'DELTAP[' + b + ']', n, stack);
+
+    for(var i = 0; i < n; i++)
+    {
+        var pi = stack.pop();
+        var arg = stack.pop();
+        var appem = base + ((arg & 0xF0)>>4);
+        if (appem !== ppem) continue;
+
+        var mag = (arg & 0x0F) - 8;
+        if (mag >= 0) mag++;
+        if (DEBUG) console.log(state.step, 'DELTAPFIX', pi, 'by', mag * ds);
+        
+        var p = z0[pi];
+        fv.setRelative(p, p, mag * ds, pv);
+    }
+}
+
+
+// SDB[] Set Delta Base in the graphics state
+// 0x5E
+function SDB(state) {
+    var stack = state.stack;
+
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SDB[]', n);
+
+    state.deltaBase = n;
+}
+
+
+// SDS[] Set Delta Shift in the graphics state
+// 0x5F
+function SDS(state) {
+    var stack = state.stack;
+
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SDS[]', n);
+
+    state.deltaShift = Math.pow(0.5, n);
+}
+
+
+// ADD[] ADD
+// 0x60
+function ADD(state) {
+    var stack = state.stack;
+
+    var n2 = stack.pop();
+    var n1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'ADD[]', n2, n1);
+
+    stack.push(n1 + n2);
+}
+
+
+// SUB[] SUB
+// 0x61
+function SUB(state) {
+    var stack = state.stack;
+
+    var n2 = stack.pop();
+    var n1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SUB[]', n2, n1);
+
+    stack.push(n1 - n2);
+}
+
+
+// DIV[] DIV
+// 0x62
+function DIV(state) {
+    var stack = state.stack;
+
+    var n2 = stack.pop();
+    var n1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'DIV[]', n2, n1);
+
+    stack.push(n1 * 64 / n2);
+}
+
+
+// MUL[] MUL
+// 0x63
+function MUL(state) {
+    var stack = state.stack;
+
+    var n2 = stack.pop();
+    var n1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'MUL[]', n2, n1);
+
+    stack.push(n1 * n2 / 64);
+}
+
+
+// ABS[] ABSolute value
+// 0x64
+function ABS(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'ABS[]', n);
+
+    stack.push(Math.abs(n));
+}
+
+
+
+// NEG[] NEGate
+// 0x65
+function NEG(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'NEG[]', n);
+
+    stack.push(-n);
+}
+
+
+// FLOOR[] FLOOR
+// 0x66
+function FLOOR(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'FLOOR[]', n);
+
+    stack.push(Math.floor(n / 0x40) * 0x40);
+}
+
+
+// CEILING[] CEILING
+// 0x67
+function CEILING(state) {
+    var stack = state.stack;
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'CEILING[]', n);
+
+    stack.push(Math.ceil(n / 0x40) * 0x40);
+}
+
+
+// ROUND[ab] ROUND value
+// 0x68-0x6B
+function ROUND(dt, state) {
+    var stack = state.stack;
+
+    var n = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'ROUND[]');
+
+    stack.push(state.round(n / 0x40) * 0x40);
+}
+
+
+// WCVTF[] Write Control Value Table in Funits
+// 0x70
+function WCVTF(state) {
+    var stack = state.stack;
+
+    var v = stack.pop();
+    var l = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'WCVTF[]', v, l);
+
+    state.cvt[l] = v * state.ppem / state.font.unitsPerEm;
+}
+
+
+// DELTAC1[] DELTA exception C1
+// DELTAC2[] DELTA exception C2
+// DELTAC3[] DELTA exception C3
+// 0x73, 0x74, 0x75
+function DELTAC123(b, state) {
+    var stack = state.stack;
+    var n = stack.pop();
+    var ppem = state.ppem;
+    var base = state.deltaBase + (b - 1) * 16;
+    var ds = state.deltaShift;
+
+    if (DEBUG) console.log(state.step, 'DELTAC[' + b + ']', n, stack);
+
+    for(var i = 0; i < n; i++)
+    {
+        var c = stack.pop();
+        var arg = stack.pop();
+        var appem = base + ((arg & 0xF0)>>4);
+        if (appem !== ppem) continue;
+
+        var mag = (arg & 0x0F) - 8;
+        if (mag >= 0) mag++;
+
+        var delta = mag * ds;
+
+        if (DEBUG) console.log(state.step, 'DELTACFIX', c, 'by', delta);
+       
+        state.cvt[c] += delta;
+    }
+}
+
+
+// SROUND[] Super ROUND
+// 0x76
+function SROUND(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'SROUND[]', n);
+
+    state.round = roundSuper;
+
+    var period;
+
+    switch (n & 0xC0)
+    {
+        case 0x00: period = 0.5; break;
+        case 0x40: period = 1; break;
+        case 0x80: period = 2; break;
+        default: throw new Error('invalid SROUND value');
+    }
+
+    state.srPeriod = period;
+
+    switch (n & 0x30)
+    {
+        case 0x00: state.srPhase = 0; break;
+        case 0x10: state.srPhase = 0.25 * period; break;
+        case 0x20: state.srPhase = 0.5  * period; break;
+        case 0x30: state.srPhase = 0.75 * period; break;
+        default: throw new Error('invalid SROUND value');
+    }
+        
+    n &= 0x0F;
+    
+    if( n === 0 ) state.srThreshold = 0;
+    else state.srThreshold = (n/8 - 0.5) * period;
+}
+
+
+// S45ROUND[] Super ROUND 45 degrees
+// 0x77
+function S45ROUND(state) {
+    var n = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'S45ROUND[]', n);
+
+    state.round = roundSuper;
+
+    var period;
+
+    switch (n & 0xC0)
+    {
+        case 0x00: period = Math.sqrt(2) / 2; break;
+        case 0x40: period = Math.sqrt(2); break;
+        case 0x80: period = 2 * Math.sqrt(2); break;
+        default: throw new Error('invalid S45ROUND value');
+    }
+
+    state.srPeriod = period;
+
+    switch (n & 0x30)
+    {
+        case 0x00: state.srPhase = 0; break;
+        case 0x10: state.srPhase = 0.25 * period; break;
+        case 0x20: state.srPhase = 0.5  * period; break;
+        case 0x30: state.srPhase = 0.75 * period; break;
+        default: throw new Error('invalid S45ROUND value');
+    }
+        
+    n &= 0x0F;
+    
+    if( n === 0 ) state.srThreshold = 0;
+    else state.srThreshold = (n/8 - 0.5) * period;
+}
+
+
+// ROFF[] Round Off
+// 0x7A
+function ROFF(state) {
+    if (DEBUG) console.log(state.step, 'ROFF[]');
+
+    state.round = roundOff;
+}
+
+
+// RUTG[] Round Up To Grid
+// 0x7C
+function RUTG(state) {
+    if (DEBUG) console.log(state.step, 'RUTG[]');
+
+    state.round = roundUpToGrid;
+}
+
+
+// RDTG[] Round Down To Grid
+// 0x7D
+function RDTG(state) {
+    if (DEBUG) console.log(state.step, 'RDTG[]');
+    
+    state.round = roundDownToGrid;
+}
+
+
+// SCANCTRL[] SCAN conversion ConTRoL
+// 0x85
+function SCANCTRL(state) {
+    var n = state.stack.pop();
+
+    // ignored by opentype.js
+
+    if (DEBUG) console.log(state.step, 'SCANCTRL[]', n);
+}
+
+
+
+// SDPVTL[a] Set Dual Projection Vector To Line
+// 0x86-0x87
+function SDPVTL(a, state) {
+    var stack = state.stack;
+    var p2i = stack.pop();
+    var p1i = stack.pop();
+    var p2 = state.z2[p2i];
+    var p1 = state.z1[p1i];
+
+    if (DEBUG) {
+        console.log( 'SDPVTL[' + a + ']', p2i, p1i );
+    }
+
+    var dx, dy;
+
+    if (!a) {
+        dx = p1.x - p2.x;
+        dy = p1.y - p2.y;
+    } else {
+        dx = p2.y - p1.y;
+        dy = p1.x - p2.x;
+    }
+
+    state.dpv = getUnitVector(dx, dy);
+}
+
+
+// GETINFO[] GET INFOrmation
+// 0x88
+function GETINFO(state) {
+    var stack = state.stack;
+    var sel = stack.pop();
+    var r = 0;
+   
+    if (DEBUG) console.log(state.step, 'GETINFO[]', sel);
+    
+    // v35 as in no subpixel hinting
+    if (sel & 0x01) r = 35;
+
+    // TODO rotation and stretch currently not supported
+    // and thus those GETINFO are always 0.
+
+    // opentype.js is always gray scaling
+    if (sel & 0x20) r |= 0x1000; 
+
+    stack.push(r);
+}
+
+
+// ROLL[] ROLL the top three stack elements
+// 0x8A
+function ROLL(state) {
+    var stack = state.stack;
+
+    var a = stack.pop();
+    var b = stack.pop();
+    var c = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'ROLL[]');
+
+    stack.push(b);
+    stack.push(a);
+    stack.push(c);
+}
+
+
+// MAX[] MAXimum of top two stack elements
+// 0x8B
+function MAX(state) {
+    var stack = state.stack;
+
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'MAX[]', e2, e1);
+
+    stack.push(Math.max(e1, e2));
+}
+
+
+// MIN[] MINimum of top two stack elements
+// 0x8C
+function MIN(state) {
+    var stack = state.stack;
+
+    var e2 = stack.pop();
+    var e1 = stack.pop();
+
+    if (DEBUG) console.log(state.step, 'MIN[]', e2, e1);
+
+    stack.push(Math.min(e1, e2));
+}
+
+
+// SCANTYPE[] SCANTYPE
+// 0x8D
+function SCANTYPE(state) {
+    var n = state.stack.pop();
+
+    // ignored by opentype.js
+
+    if (DEBUG) console.log(state.step, 'SCANTYPE[]', n);
+}
+
+
+// INSTCTRL[] INSTCTRL
+// 0x8D
+function INSTCTRL(state) {
+    var s = state.stack.pop();
+    var v = state.stack.pop();
+
+    if (DEBUG) console.log(state.step, 'INSTCTRL[]', s, v);
+
+    switch(s) {
+        case 1 : state.inhibitGridFit = !!v; return;
+        case 2 : state.ignoreCvt = !!v; return;
+        default: throw new Error('invalid INSTCTRL[] selector');
+    }
+}
+
+
+// PUSHB[abc] PUSH Bytes
+// 0xB0-0xB7
+function PUSHB(n, state) {
+    var stack = state.stack;
+    var prog = state.prog;
+    var ip = state.ip;
+
+    if (DEBUG) console.log(state.step, 'PUSHB[' + n + ']');
+
+    for (var i = 0; i < n; i++) stack.push(prog[++ip]);
+
+    state.ip = ip;
+}
+
+
+// PUSHW[abc] PUSH Words
+// 0xB8-0xBF
+function PUSHW(n, state) {
+    var ip = state.ip;
+    var prog = state.prog;
+    var stack = state.stack;
+
+    if (DEBUG) console.log(state.ip, 'PUSHW[' + n + ']');
+
+    for (var i = 0; i < n; i++) {
+        var w = (prog[++ip] << 8) | prog[++ip];
+        if (w & 0x8000) w = -((w^0xffff)+1);
+        stack.push(w);
+    }
+    
+    state.ip = ip;
+}
+
+
+// MDRP[abcde] Move Direct Relative Point
+// 0xD0-0xEF
+// (if indirect is 0)
+//
+// and
+//
+// MIRP[abcde] Move Indirect Relative Point
+// 0xE0-0xFF
+// (if indirect is 1)
+
+function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
+    var stack = state.stack;
+    var cvte = indirect && stack.pop();
+    var pi = stack.pop();
+    var rp0i = state.rp0;
+    var rp = state.z0[rp0i];
+    var p = state.z1[pi];
+
+    var md = state.minDis;
+    var fv = state.fv;
+    var pv = state.dpv;
+    var od; // original distance
+    var d; // moving distance
+    var sign; // sign of distance
+    var cv;
+    
+    d = od = pv.distance(p, rp, true, true);
+    sign = d > 0 ? 1 : -1; // Math.sign would be 0 in case of 0
+    
+    // TODO consider autoFlip
+    d = Math.abs(d);
+
+    if (indirect) {
+        cv = state.cvt[cvte];
+
+        if (ro && Math.abs(d - cv) < state.cvCutIn) d = cv;
+    }
+    
+    if (keepD && d < md) d = md;
+    
+    if (ro) d = state.round(d);
+
+    fv.setRelative(p, rp, sign * d, pv);
+    fv.touch(p);
+
+    if (DEBUG) {
+        console.log(
+            state.step,
+            ( indirect ? 'MIRP[' : 'MDRP[' )
+            + (setRp0 ? 'M' : 'm')
+            + (keepD ? '>' : '_')
+            + (ro ? 'R' : '_')
+            + (dt === 0 ? 'Gr' : (dt === 1 ? 'Bl' : (dt === 2 ? 'Wh' : '')))
+            + ']',
+            indirect
+                ?  cvte + '(' + state.cvt[cvte] + ',' +  cv + ')'
+                : '',
+            pi,
+            '(d =', od, '->', sign * d, ')'
+        );
+    }
+
+    state.rp1 = state.rp0;
+    state.rp2 = pi;
+    if (setRp0) state.rp0 = pi;
+}
+
+
+/*
+* The instruction table.
+*/
+instructionTable = [
+    /* 0x00 */ SVTCA.bind(undefined, yUnitVector),
+    /* 0x01 */ SVTCA.bind(undefined, xUnitVector),
+    /* 0x02 */ SPVTCA.bind(undefined, yUnitVector),
+    /* 0x03 */ SPVTCA.bind(undefined, xUnitVector),
+    /* 0x04 */ SFVTCA.bind(undefined, yUnitVector),
+    /* 0x05 */ SFVTCA.bind(undefined, xUnitVector),
+    /* 0x06 */ SPVTL.bind(undefined, 0 ),
+    /* 0x07 */ SPVTL.bind(undefined, 1 ),
+    /* 0x08 */ SFVTL.bind(undefined, 0 ),
+    /* 0x09 */ SFVTL.bind(undefined, 1 ),
+    /* 0x0A */ SPVFS,
+    /* 0x0B */ SFVFS,
+    /* 0x0C */ GPV,
+    /* 0x0D */ GFV,
+    /* 0x0E */ SFVTPV,
+    /* 0x0F */ ISECT,
+    /* 0x10 */ SRP0,
+    /* 0x11 */ SRP1,
+    /* 0x12 */ SRP2,
+    /* 0x13 */ SZP0,
+    /* 0x14 */ SZP1,
+    /* 0x15 */ SZP2,
+    /* 0x16 */ SZPS,
+    /* 0x17 */ SLOOP,
+    /* 0x18 */ RTG,
+    /* 0x19 */ RTHG,
+    /* 0x1A */ SMD,
+    /* 0x1B */ ELSE,
+    /* 0x1C */ JMPR,
+    /* 0x1D */ SCVTCI,
+    /* 0x1E */ undefined,   // TODO SSWCI
+    /* 0x1F */ undefined,   // TODO SSW
+    /* 0x20 */ DUP,
+    /* 0x21 */ POP,
+    /* 0x22 */ CLEAR,
+    /* 0x23 */ SWAP,
+    /* 0x24 */ DEPTH,
+    /* 0x25 */ CINDEX,
+    /* 0x26 */ MINDEX,
+    /* 0x27 */ undefined,   // TODO ALIGNPTS
+    /* 0x28 */ undefined,
+    /* 0x29 */ undefined,   // TODO UTP
+    /* 0x2A */ LOOPCALL,
+    /* 0x2B */ CALL,
+    /* 0x2C */ FDEF,
+    /* 0x2D */ undefined,   // ENDF (eaten by FDEF)
+    /* 0x2E */ MDAP.bind(undefined, 0),
+    /* 0x2F */ MDAP.bind(undefined, 1),
+    /* 0x30 */ IUP.bind(undefined, yUnitVector),
+    /* 0x31 */ IUP.bind(undefined, xUnitVector),
+    /* 0x32 */ SHP.bind(undefined, 0),
+    /* 0x33 */ SHP.bind(undefined, 1),
+    /* 0x34 */ SHC.bind(undefined, 0),
+    /* 0x35 */ SHC.bind(undefined, 1),
+    /* 0x36 */ SHZ.bind(undefined, 0),
+    /* 0x37 */ SHZ.bind(undefined, 1),
+    /* 0x38 */ SHPIX,
+    /* 0x39 */ IP,
+    /* 0x3A */ MSIRP.bind(undefined, 0),
+    /* 0x3B */ MSIRP.bind(undefined, 1),
+    /* 0x3C */ ALIGNRP,
+    /* 0x3D */ RTDG,
+    /* 0x3E */ MIAP.bind(undefined, 0),
+    /* 0x3F */ MIAP.bind(undefined, 1),
+    /* 0x40 */ NPUSHB,
+    /* 0x41 */ NPUSHW,
+    /* 0x42 */ WS,
+    /* 0x43 */ RS,
+    /* 0x44 */ WCVTP,
+    /* 0x45 */ RCVT,
+    /* 0x46 */ GC.bind(undefined, 0),
+    /* 0x47 */ GC.bind(undefined, 1),
+    /* 0x48 */ undefined,   // TODO SCFS
+    /* 0x49 */ MD.bind(undefined, 0),
+    /* 0x4A */ MD.bind(undefined, 1),
+    /* 0x4B */ MPPEM,
+    /* 0x4C */ undefined,   // TODO MPS
+    /* 0x4D */ FLIPON,
+    /* 0x4E */ undefined,   // TODO FLIPOFF
+    /* 0x4F */ undefined,   // TODO DEBUG
+    /* 0x50 */ LT,
+    /* 0x51 */ LTEQ,
+    /* 0x52 */ GT,
+    /* 0x53 */ GTEQ,
+    /* 0x54 */ EQ,
+    /* 0x55 */ NEQ,
+    /* 0x56 */ ODD,
+    /* 0x57 */ EVEN,
+    /* 0x58 */ IF,
+    /* 0x59 */ EIF,
+    /* 0x5A */ AND,
+    /* 0x5B */ OR,
+    /* 0x5C */ NOT,
+    /* 0x5D */ DELTAP123.bind(undefined, 1),
+    /* 0x5E */ SDB,
+    /* 0x5F */ SDS,
+    /* 0x60 */ ADD,
+    /* 0x61 */ SUB,
+    /* 0x62 */ DIV,
+    /* 0x63 */ MUL,
+    /* 0x64 */ ABS,
+    /* 0x65 */ NEG,
+    /* 0x66 */ FLOOR,
+    /* 0x67 */ CEILING,
+    /* 0x68 */ ROUND.bind(undefined, 0),
+    /* 0x69 */ ROUND.bind(undefined, 1),
+    /* 0x6A */ ROUND.bind(undefined, 2),
+    /* 0x6B */ ROUND.bind(undefined, 3),
+    /* 0x6C */ undefined,   // TODO NROUND[ab]
+    /* 0x6D */ undefined,   // TODO NROUND[ab]
+    /* 0x6E */ undefined,   // TODO NROUND[ab]
+    /* 0x6F */ undefined,   // TODO NROUND[ab]
+    /* 0x70 */ WCVTF,
+    /* 0x71 */ DELTAP123.bind(undefined, 2),
+    /* 0x72 */ DELTAP123.bind(undefined, 3),
+    /* 0x73 */ DELTAC123.bind(undefined, 1),
+    /* 0x74 */ DELTAC123.bind(undefined, 2),
+    /* 0x75 */ DELTAC123.bind(undefined, 3),
+    /* 0x76 */ SROUND,
+    /* 0x77 */ S45ROUND,
+    /* 0x78 */ undefined,   // TODO JROT[]
+    /* 0x79 */ undefined,   // TODO JROF[]
+    /* 0x7A */ ROFF,
+    /* 0x7B */ undefined,
+    /* 0x7C */ RUTG,
+    /* 0x7D */ RDTG,
+    /* 0x7E */ POP, // actually SANGW, supposed to do only a pop though
+    /* 0x7F */ POP, // actually AA, upposed to do only a pop though
+    /* 0x80 */ undefined,   // TODO FLIPPT
+    /* 0x81 */ undefined,   // TODO FLIPRGON
+    /* 0x82 */ undefined,   // TODO FLIPRGOFF
+    /* 0x83 */ undefined,
+    /* 0x84 */ undefined,
+    /* 0x85 */ SCANCTRL,
+    /* 0x86 */ SDPVTL.bind(undefined, 0),
+    /* 0x87 */ SDPVTL.bind(undefined, 1),
+    /* 0x88 */ GETINFO,
+    /* 0x89 */ undefined,   // TODO IDEF
+    /* 0x8A */ ROLL,
+    /* 0x8B */ MAX,
+    /* 0x8C */ MIN,
+    /* 0x8D */ SCANTYPE,
+    /* 0x8E */ INSTCTRL,
+    /* 0x8F */ undefined,
+    /* 0x90 */ undefined,
+    /* 0x91 */ undefined,
+    /* 0x92 */ undefined,
+    /* 0x93 */ undefined,
+    /* 0x94 */ undefined,
+    /* 0x95 */ undefined,
+    /* 0x96 */ undefined,
+    /* 0x97 */ undefined,
+    /* 0x98 */ undefined,
+    /* 0x99 */ undefined,
+    /* 0x9A */ undefined,
+    /* 0x9B */ undefined,
+    /* 0x9C */ undefined,
+    /* 0x9D */ undefined,
+    /* 0x9E */ undefined,
+    /* 0x9F */ undefined,
+    /* 0xA0 */ undefined,
+    /* 0xA1 */ undefined,
+    /* 0xA2 */ undefined,
+    /* 0xA3 */ undefined,
+    /* 0xA4 */ undefined,
+    /* 0xA5 */ undefined,
+    /* 0xA6 */ undefined,
+    /* 0xA7 */ undefined,
+    /* 0xA8 */ undefined,
+    /* 0xA9 */ undefined,
+    /* 0xAA */ undefined,
+    /* 0xAB */ undefined,
+    /* 0xAC */ undefined,
+    /* 0xAD */ undefined,
+    /* 0xAE */ undefined,
+    /* 0xAF */ undefined,
+    /* 0xB0 */ PUSHB.bind(undefined, 1),
+    /* 0xB1 */ PUSHB.bind(undefined, 2),
+    /* 0xB2 */ PUSHB.bind(undefined, 3),
+    /* 0xB3 */ PUSHB.bind(undefined, 4),
+    /* 0xB4 */ PUSHB.bind(undefined, 5),
+    /* 0xB5 */ PUSHB.bind(undefined, 6),
+    /* 0xB6 */ PUSHB.bind(undefined, 7),
+    /* 0xB7 */ PUSHB.bind(undefined, 8),
+    /* 0xB8 */ PUSHW.bind(undefined, 1),
+    /* 0xB9 */ PUSHW.bind(undefined, 2),
+    /* 0xBA */ PUSHW.bind(undefined, 3),
+    /* 0xBB */ PUSHW.bind(undefined, 4),
+    /* 0xBC */ PUSHW.bind(undefined, 5),
+    /* 0xBD */ PUSHW.bind(undefined, 6),
+    /* 0xBE */ PUSHW.bind(undefined, 7),
+    /* 0xBF */ PUSHW.bind(undefined, 8),
+    /* 0xC0 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 0, 0),
+    /* 0xC1 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 0, 1),
+    /* 0xC2 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 0, 2),
+    /* 0xC3 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 0, 3),
+    /* 0xC4 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 1, 0),
+    /* 0xC5 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 1, 1),
+    /* 0xC6 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 1, 2),
+    /* 0xC7 */ MDRP_MIRP.bind(undefined, 0, 0, 0, 1, 3),
+    /* 0xC8 */ MDRP_MIRP.bind(undefined, 0, 0, 1, 0, 0),
+    /* 0xC9 */ MDRP_MIRP.bind(undefined, 0, 0, 1, 0, 1),
+    /* 0xCA */ MDRP_MIRP.bind(undefined, 0, 0, 1, 0, 2),
+    /* 0xCB */ MDRP_MIRP.bind(undefined, 0, 0, 1, 0, 3),
+    /* 0xCC */ MDRP_MIRP.bind(undefined, 0, 0, 1, 1, 0),
+    /* 0xCD */ MDRP_MIRP.bind(undefined, 0, 0, 1, 1, 1),
+    /* 0xCE */ MDRP_MIRP.bind(undefined, 0, 0, 1, 1, 2),
+    /* 0xCF */ MDRP_MIRP.bind(undefined, 0, 0, 1, 1, 3),
+    /* 0xD0 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 0, 0),
+    /* 0xD1 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 0, 1),
+    /* 0xD2 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 0, 2),
+    /* 0xD3 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 0, 3),
+    /* 0xD4 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 1, 0),
+    /* 0xD5 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 1, 1),
+    /* 0xD6 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 1, 2),
+    /* 0xD7 */ MDRP_MIRP.bind(undefined, 0, 1, 0, 1, 3),
+    /* 0xD8 */ MDRP_MIRP.bind(undefined, 0, 1, 1, 0, 0),
+    /* 0xD9 */ MDRP_MIRP.bind(undefined, 0, 1, 1, 0, 1),
+    /* 0xDA */ MDRP_MIRP.bind(undefined, 0, 1, 1, 0, 2),
+    /* 0xDB */ MDRP_MIRP.bind(undefined, 0, 1, 1, 0, 3),
+    /* 0xDC */ MDRP_MIRP.bind(undefined, 0, 1, 1, 1, 0),
+    /* 0xDD */ MDRP_MIRP.bind(undefined, 0, 1, 1, 1, 1),
+    /* 0xDE */ MDRP_MIRP.bind(undefined, 0, 1, 1, 1, 2),
+    /* 0xDF */ MDRP_MIRP.bind(undefined, 0, 1, 1, 1, 3),
+    /* 0xE0 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 0, 0),
+    /* 0xE1 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 0, 1),
+    /* 0xE2 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 0, 2),
+    /* 0xE3 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 0, 3),
+    /* 0xE4 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 1, 0),
+    /* 0xE5 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 1, 1),
+    /* 0xE6 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 1, 2),
+    /* 0xE7 */ MDRP_MIRP.bind(undefined, 1, 0, 0, 1, 3),
+    /* 0xE8 */ MDRP_MIRP.bind(undefined, 1, 0, 1, 0, 0),
+    /* 0xE9 */ MDRP_MIRP.bind(undefined, 1, 0, 1, 0, 1),
+    /* 0xEA */ MDRP_MIRP.bind(undefined, 1, 0, 1, 0, 2),
+    /* 0xEB */ MDRP_MIRP.bind(undefined, 1, 0, 1, 0, 3),
+    /* 0xEC */ MDRP_MIRP.bind(undefined, 1, 0, 1, 1, 0),
+    /* 0xED */ MDRP_MIRP.bind(undefined, 1, 0, 1, 1, 1),
+    /* 0xEE */ MDRP_MIRP.bind(undefined, 1, 0, 1, 1, 2),
+    /* 0xEF */ MDRP_MIRP.bind(undefined, 1, 0, 1, 1, 3),
+    /* 0xF0 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 0, 0),
+    /* 0xF1 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 0, 1),
+    /* 0xF2 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 0, 2),
+    /* 0xF3 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 0, 3),
+    /* 0xF4 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 1, 0),
+    /* 0xF5 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 1, 1),
+    /* 0xF6 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 1, 2),
+    /* 0xF7 */ MDRP_MIRP.bind(undefined, 1, 1, 0, 1, 3),
+    /* 0xF8 */ MDRP_MIRP.bind(undefined, 1, 1, 1, 0, 0),
+    /* 0xF9 */ MDRP_MIRP.bind(undefined, 1, 1, 1, 0, 1),
+    /* 0xFA */ MDRP_MIRP.bind(undefined, 1, 1, 1, 0, 2),
+    /* 0xFB */ MDRP_MIRP.bind(undefined, 1, 1, 1, 0, 3),
+    /* 0xFC */ MDRP_MIRP.bind(undefined, 1, 1, 1, 1, 0),
+    /* 0xFD */ MDRP_MIRP.bind(undefined, 1, 1, 1, 1, 1),
+    /* 0xFE */ MDRP_MIRP.bind(undefined, 1, 1, 1, 1, 2),
+    /* 0xFF */ MDRP_MIRP.bind(undefined, 1, 1, 1, 1, 3)
+];
+
+
+module.exports = Hinting;
+
+
+/*****************************
+  Mathematical Considertions
+******************************
+
+fv ... refers to freedom vector
+pv ... refers to projection vector
+rp ... refers to reference point
+p  ... refers to to point being operated on
+d  ... refers to distance
+
+SETRELATIVE:
+============
+
+freedom vector = x-axis:
+------------------------
+
+                        (pv)
+                     .-'
+              rpd .-'
+               .-*
+          d .-'90°'
+         .-'       '
+      .-'           '
+   *-'               ' b
+  rp                  '
+                       '
+                        '
+            p *----------*-------------- (fv)
+                          pm
+
+  rpdx = rpx + d * pv.x
+  rpdy = rpy + d * pv.y
+
+  equation of line b
+
+   y - rpdy = pvns * (x- rpdx)
+
+   y = p.y
+
+   x = rpdx + ( p.y - rpdy ) / pvns
+
+
+freedom vector = y-axis:
+------------------------
+
+    * pm
+    |\
+    | \
+    |  \
+    |   \
+    |    \
+    |     \
+    |      \
+    |       \
+    |        \
+    |         \ b
+    |          \
+    |           \
+    |            \    .-' (pv)
+    |         90° \.-'
+    |           .-'* rpd
+    |        .-'
+    *     *-'  d
+    p     rp    
+                
+  rpdx = rpx + d * pv.x
+  rpdy = rpy + d * pv.y
+
+  equation of line b:
+           pvns ... normal slope to pv
+
+   y - rpdy = pvns * (x - rpdx)
+   
+   x = p.x
+
+   y = rpdy +  pvns * (p.x - rpdx)
+
+
+
+generic case:
+-------------
+
+                        
+                              .'(fv)
+                            .'
+                          .* pm
+                        .' !
+                      .'    .
+                    .'      !
+                  .'         . b
+                .'           !
+               *              .
+              p               !
+                         90°   .    ... (pv)
+                           ...-*-'''
+                  ...---'''    rpd
+         ...---'''   d
+   *--'''
+  rp
+  
+    rpdx = rpx + d * pv.x
+    rpdy = rpy + d * pv.y
+
+ equation of line b:
+    pvns... normal slope to pv
+
+    y - rpdy = pvns * (x - rpdx)
+ 
+ equation of freedom vector line:
+    fvs ... slope of freedom vector (=fy/fx)
+  
+    y - py = fvs * (x - px)
+
+
+  on pm both equations are true for same x/y
+
+    y - rpdy = pvns * (x - rpdx)
+
+    y - py = fvs * (x - px)
+
+  form to y and set equal:
+
+    pvns * (x - rpdx) + rpdy = fvs * (x - px) + py
+
+  expand: 
+    
+    pvns * x - pvns * rpdx + rpdy = fvs * x - fvs * px + py
+
+  switch:
+
+    fvs * x - fvs * px + py = pvns * x - pvns * rpdx + rpdy
+
+  solve for x:
+
+    fvs * x - pvns * x = fvs * px - pvns * rpdx - py + rpdy
+
+
+
+          fvs * px - pvns * rpdx + rpdy - py
+    x =  -----------------------------------
+                 fvs - pvns
+
+  and:
+
+    y = fvs * (x - px) + py
+
+
+
+INTERPOLATE:
+============
+
+Examples of point interpolation.
+
+The weight of the movement of the reference point gets bigger
+the further the other reference point is away, thus the safest
+option (that is avoiding 0/0 divisions) is to weight the
+original distance of the other point by the sum of both distances.
+
+If the sum of both distances is 0, then move the point by the
+arithmetic average of the movement of both refererence points.
+
+
+
+
+           (+6)    
+    rp1o *---->*rp1
+         .     .                          (+12)
+         .     .                  rp2o *---------->* rp2
+         .     .                       .           .
+         .     .                       .           .
+         .    10          20           .           .
+         |.........|...................|           .
+               .   .                               .
+               .   . (+8)                          .
+                po *------>*p                      .
+               .           .                       .
+               .    12     .          24           .
+               |...........|.......................|
+                                  36
+
+     
+-------
+
+
+
+           (+10)    
+    rp1o *-------->*rp1
+         .         .                      (-10)
+         .         .              rp2 *<---------* rpo2
+         .         .                   .         .
+         .         .                   .         .
+         .    10   .          30       .         .
+         |.........|.............................|
+                   .                   .         
+                   . (+5)              .
+                po *--->* p            .         
+                   .    .              .
+                   .    .   20         .
+                   |....|..............|
+                     5        15
+     
+
+-------
+
+
+           (+10)    
+    rp1o *-------->*rp1
+         .         .
+         .         .
+    rp2o *-------->*rp2
+
+
+                               (+10)
+                          po *-------->* p
+
+-------
+
+
+           (+10)    
+    rp1o *-------->*rp1
+         .         .
+         .         .(+30)
+    rp2o *---------------------------->*rp2
+
+
+                                        (+25)
+                          po *----------------------->* p
+
+
+
+vim: set ts=4 sw=4 expandtab:
+*****/

--- a/src/hintingtt.js
+++ b/src/hintingtt.js
@@ -2342,7 +2342,7 @@ function SDPVTL(a, state) {
     var p2 = state.z2[p2i];
     var p1 = state.z1[p1i];
 
-    if (DEBUG) console.log('SDPVTL[' + a + ']', p2i, p1i );
+    if (DEBUG) console.log('SDPVTL[' + a + ']', p2i, p1i);
 
     var dx;
     var dy;
@@ -2364,7 +2364,7 @@ function GETINFO(state) {
     var stack = state.stack;
     var sel = stack.pop();
     var r = 0;
-   
+
     if (DEBUG) console.log(state.step, 'GETINFO[]', sel);
 
     // v35 as in no subpixel hinting
@@ -2439,7 +2439,7 @@ function INSTCTRL(state) {
 
     if (DEBUG) console.log(state.step, 'INSTCTRL[]', s, v);
 
-    switch(s) {
+    switch (s) {
         case 1 : state.inhibitGridFit = !!v; return;
         case 2 : state.ignoreCvt = !!v; return;
         default: throw new Error('invalid INSTCTRL[] selector');
@@ -2471,10 +2471,10 @@ function PUSHW(n, state) {
 
     for (var i = 0; i < n; i++) {
         var w = (prog[++ip] << 8) | prog[++ip];
-        if (w & 0x8000) w = -((w^0xffff)+1);
+        if (w & 0x8000) w = -((w ^ 0xffff) + 1);
         stack.push(w);
     }
-    
+
     state.ip = ip;
 }
 
@@ -2503,10 +2503,10 @@ function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
     var d; // moving distance
     var sign; // sign of distance
     var cv;
-    
+
     d = od = pv.distance(p, rp, true, true);
     sign = d > 0 ? 1 : -1; // Math.sign would be 0 in case of 0
-    
+
     // TODO consider autoFlip
     d = Math.abs(d);
 
@@ -2515,9 +2515,9 @@ function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
 
         if (ro && Math.abs(d - cv) < state.cvCutIn) d = cv;
     }
-    
+
     if (keepD && d < md) d = md;
-    
+
     if (ro) d = state.round(d);
 
     fv.setRelative(p, rp, sign * d, pv);
@@ -2526,7 +2526,7 @@ function MDRP_MIRP(indirect, setRp0, keepD, ro, dt, state) {
     if (DEBUG) {
         console.log(
             state.step,
-            ( indirect ? 'MIRP[' : 'MDRP[' ) +
+            (indirect ? 'MIRP[' : 'MDRP[') +
             (setRp0 ? 'M' : 'm') +
             (keepD ? '>' : '_') +
             (ro ? 'R' : '_') +
@@ -2555,10 +2555,10 @@ instructionTable = [
     /* 0x03 */ SPVTCA.bind(undefined, xUnitVector),
     /* 0x04 */ SFVTCA.bind(undefined, yUnitVector),
     /* 0x05 */ SFVTCA.bind(undefined, xUnitVector),
-    /* 0x06 */ SPVTL.bind(undefined, 0 ),
-    /* 0x07 */ SPVTL.bind(undefined, 1 ),
-    /* 0x08 */ SFVTL.bind(undefined, 0 ),
-    /* 0x09 */ SFVTL.bind(undefined, 1 ),
+    /* 0x06 */ SPVTL.bind(undefined, 0),
+    /* 0x07 */ SPVTL.bind(undefined, 1),
+    /* 0x08 */ SFVTL.bind(undefined, 0),
+    /* 0x09 */ SFVTL.bind(undefined, 1),
     /* 0x0A */ SPVFS,
     /* 0x0B */ SFVFS,
     /* 0x0C */ GPV,
@@ -2872,8 +2872,8 @@ freedom vector = y-axis:
     |           .-'* rpd
     |        .-'
     *     *-'  d
-    p     rp    
-                
+    p     rp
+
   rpdx = rpx + d * pv.x
   rpdy = rpy + d * pv.y
 
@@ -2891,7 +2891,7 @@ freedom vector = y-axis:
 generic case:
 -------------
 
-                        
+
                               .'(fv)
                             .'
                           .* pm
@@ -2908,7 +2908,7 @@ generic case:
          ...---'''   d
    *--'''
   rp
-  
+
     rpdx = rpx + d * pv.x
     rpdy = rpy + d * pv.y
 
@@ -2916,10 +2916,10 @@ generic case:
     pvns... normal slope to pv
 
     y - rpdy = pvns * (x - rpdx)
- 
+
  equation of freedom vector line:
     fvs ... slope of freedom vector (=fy/fx)
-  
+
     y - py = fvs * (x - px)
 
 
@@ -2933,7 +2933,7 @@ generic case:
 
     pvns * (x - rpdx) + rpdy = fvs * (x - px) + py
 
-  expand: 
+  expand:
     
     pvns * x - pvns * rpdx + rpdy = fvs * x - fvs * px + py
 
@@ -2973,7 +2973,7 @@ arithmetic average of the movement of both refererence points.
 
 
 
-           (+6)    
+           (+6)
     rp1o *---->*rp1
          .     .                          (+12)
          .     .                  rp2o *---------->* rp2
@@ -2989,12 +2989,12 @@ arithmetic average of the movement of both refererence points.
                |...........|.......................|
                                   36
 
-     
+
 -------
 
 
 
-           (+10)    
+           (+10)
     rp1o *-------->*rp1
          .         .                      (-10)
          .         .              rp2 *<---------* rpo2
@@ -3014,7 +3014,7 @@ arithmetic average of the movement of both refererence points.
 -------
 
 
-           (+10)    
+           (+10)
     rp1o *-------->*rp1
          .         .
          .         .
@@ -3027,7 +3027,7 @@ arithmetic average of the movement of both refererence points.
 -------
 
 
-           (+10)    
+           (+10)
     rp1o *-------->*rp1
          .         .
          .         .(+30)

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -214,6 +214,7 @@ function parseBuffer(buffer) {
     var locaTableEntry;
     var nameTableEntry;
     var metaTableEntry;
+    var p;
 
     for (var i = 0; i < numTables; i += 1) {
         var tableEntry = tableEntries[i];
@@ -224,8 +225,18 @@ function parseBuffer(buffer) {
                 font.tables.cmap = cmap.parse(table.data, table.offset);
                 font.encoding = new encoding.CmapEncoding(font.tables.cmap);
                 break;
+            case 'cvt ' :
+                table = uncompressTable(data, tableEntry);
+                p = new parse.Parser(table.data, table.offset);
+                font.tables.cvt = p.parseShortList(tableEntry.length / 2);
+                break;
             case 'fvar':
                 fvarTableEntry = tableEntry;
+                break;
+            case 'fpgm' :
+                table = uncompressTable(data, tableEntry);
+                p = new parse.Parser(table.data, table.offset);
+                font.tables.fpgm = p.parseByteList(tableEntry.length);
                 break;
             case 'head':
                 table = uncompressTable(data, tableEntry);
@@ -263,6 +274,11 @@ function parseBuffer(buffer) {
                 table = uncompressTable(data, tableEntry);
                 font.tables.post = post.parse(table.data, table.offset);
                 font.glyphNames = new encoding.GlyphNames(font.tables.post);
+                break;
+            case 'prep' :
+                table = uncompressTable(data, tableEntry);
+                p = new parse.Parser(table.data, table.offset);
+                font.tables.prep = p.parseByteList( tableEntry.length );
                 break;
             case 'glyf':
                 glyfTableEntry = tableEntry;

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -278,7 +278,7 @@ function parseBuffer(buffer) {
             case 'prep' :
                 table = uncompressTable(data, tableEntry);
                 p = new parse.Parser(table.data, table.offset);
-                font.tables.prep = p.parseByteList( tableEntry.length );
+                font.tables.prep = p.parseByteList(tableEntry.length);
                 break;
             case 'glyf':
                 glyfTableEntry = tableEntry;

--- a/src/parse.js
+++ b/src/parse.js
@@ -197,7 +197,7 @@ Parser.prototype.skip = function(type, amount) {
 
 ///// Parsing lists and records ///////////////////////////////
 
-// Parse a list of 16 bit integers. The length of the list can be read on the stream
+// Parse a list of 16 bit unsigned integers. The length of the list can be read on the stream
 // or provided as an argument.
 Parser.prototype.parseOffset16List =
 Parser.prototype.parseUShortList = function(count) {
@@ -212,6 +212,34 @@ Parser.prototype.parseUShortList = function(count) {
 
     this.relativeOffset += count * 2;
     return offsets;
+};
+
+
+// Parses a list of 16 bit signed integers.
+Parser.prototype.parseShortList = function(count) {
+    var list = new Array(count);
+    var dataView = this.data;
+    var offset = this.offset + this.relativeOffset;
+    for (var i = 0; i < count; i++) {
+        list[i] = dataView.getInt16(offset);
+        offset += 2;
+    }
+
+    this.relativeOffset += count * 2;
+    return list;
+};
+
+// Parses a list of bytes.
+Parser.prototype.parseByteList = function(count) {
+    var list = new Array(count);
+    var dataView = this.data;
+    var offset = this.offset + this.relativeOffset;
+    for (var i = 0; i < count; i++) {
+        list[i] = dataView.getUint8(offset++);
+    }
+
+    this.relativeOffset += count;
+    return list;
 };
 
 /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -214,7 +214,6 @@ Parser.prototype.parseUShortList = function(count) {
     return offsets;
 };
 
-
 // Parses a list of 16 bit signed integers.
 Parser.prototype.parseShortList = function(count) {
     var list = new Array(count);

--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -168,6 +168,14 @@ function parseGlyph(glyph, data, start) {
             glyph.components.push(component);
             moreComponents = !!(flags & 32);
         }
+        if (flags & 0x100) {
+            // We have instructions
+            glyph.instructionLength = p.parseUShort();
+            glyph.instructions = [];
+            for (i = 0; i < glyph.instructionLength; i += 1) {
+                glyph.instructions.push(p.parseByte());
+            }
+        }
     }
 }
 
@@ -331,5 +339,7 @@ function parseGlyfTable(data, start, loca, font) {
 
     return glyphs;
 }
+
+exports.getPath = getPath;
 
 exports.parse = parseGlyfTable;

--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -44,8 +44,8 @@ function parseGlyph(glyph, data, start) {
     glyph._yMax = p.parseShort();
     var flags;
     var flag;
+    var i;
     if (glyph.numberOfContours > 0) {
-        var i;
         // This glyph is not a composite.
         var endPointIndices = glyph.endPointIndices = [];
         for (i = 0; i < glyph.numberOfContours; i += 1) {


### PR DESCRIPTION
Implementing a font hinting interpreter for truetype:

Demo:

The actual canvas is the top one, the lower one has each pixel enlarged by a factor of 7.
The font used in the demo is DejaVuSans.ttf
First line is default opentype.js
Second line is opentype.js with fonthinting enabled
Third line is canvas.fillText() with @font-face.

![hintingdemo](https://cloud.githubusercontent.com/assets/495407/24370485/d99d5786-1327-11e7-8cfe-005c60da0396.png)

As you see there is hardly a difference between second and third line, except glyph advancement not being hinted. I didn't do that yet, as that would require some changes to the opentype.js.

I tried to keep all changes to opentype.js outside of src/hintingtt.js as minimal as possible. 

PS: I'll need to append a fix commits until the code styling checks stop complaining.