### PR TITLE
Fix unclosed paths for TrueType glyphs.

### DIFF
--- a/src/tables/glyf.js
+++ b/src/tables/glyf.js
@@ -266,9 +266,9 @@ function getPath(points) {
                 p.quadraticCurveTo(curr.x, curr.y, next2.x, next2.y);
             }
         }
-    }
 
-    p.closePath();
+        p.closePath();
+    }
     return p;
 }
 

--- a/test/opentypeSpec.js
+++ b/test/opentypeSpec.js
@@ -15,7 +15,7 @@ describe('OpenType.js', function() {
         var aGlyph = font.charToGlyph('A');
         assert.equal(aGlyph.name, 'A');
         assert.equal(aGlyph.unicode, 65);
-        assert.equal(aGlyph.path.commands.length, 18);
+        assert.equal(aGlyph.path.commands.length, 19);
     });
 
     it('can load a OpenType/CFF font', function() {


### PR DESCRIPTION
TrueType glyph outlines were not being closed properly; only a single closePath command was being issued for each glyph.  This fix ensures that a closePath command is issued for each contour.

