### PR TITLE
Fix discrepancy in tableEntries #275

### DIFF
--- a/dist/opentype.js
+++ b/dist/opentype.js
@@ -21,10 +21,10 @@ function Data(source, dest) {
   this.sourceIndex = 0;
   this.tag = 0;
   this.bitcount = 0;
-  
+
   this.dest = dest;
   this.destLen = 0;
-  
+
   this.ltree = new Tree();  /* dynamic length/symbol tree */
   this.dtree = new Tree();  /* dynamic distance tree */
 }
@@ -166,7 +166,7 @@ function tinf_decode_symbol(d, t) {
     d.tag |= d.source[d.sourceIndex++] << d.bitcount;
     d.bitcount += 8;
   }
-  
+
   var sum = 0, cur = 0, len = 0;
   var tag = d.tag;
 
@@ -179,7 +179,7 @@ function tinf_decode_symbol(d, t) {
     sum += t.table[len];
     cur -= t.table[len];
   } while (cur >= 0);
-  
+
   d.tag = tag;
   d.bitcount -= len;
 
@@ -290,7 +290,7 @@ function tinf_inflate_block_data(d, lt, dt) {
 function tinf_inflate_uncompressed_block(d) {
   var length, invlength;
   var i;
-  
+
   /* unread from bitbuffer */
   while (d.bitcount > 8) {
     d.sourceIndex--;
@@ -363,7 +363,7 @@ function tinf_uncompress(source, dest) {
     else
       { return d.dest.subarray(0, d.destLen); }
   }
-  
+
   return d.dest;
 }
 
@@ -11883,7 +11883,7 @@ function parseWOFFTableEntries(data, numTables) {
         }
 
         tableEntries.push({tag: tag, offset: offset, compression: compression,
-            compressedLength: compLength, originalLength: origLength});
+            compressedLength: compLength, length: origLength});
         p += 20;
     }
 
@@ -11905,9 +11905,9 @@ function parseWOFFTableEntries(data, numTables) {
 function uncompressTable(data, tableEntry) {
     if (tableEntry.compression === 'WOFF') {
         var inBuffer = new Uint8Array(data.buffer, tableEntry.offset + 2, tableEntry.compressedLength - 2);
-        var outBuffer = new Uint8Array(tableEntry.originalLength);
+        var outBuffer = new Uint8Array(tableEntry.length);
         index(inBuffer, outBuffer);
-        if (outBuffer.byteLength !== tableEntry.originalLength) {
+        if (outBuffer.byteLength !== tableEntry.length) {
             throw new Error('Decompression error: ' + tableEntry.tag + ' decompressed length doesn\'t match recorded length');
         }
 

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -122,7 +122,7 @@ function parseWOFFTableEntries(data, numTables) {
         }
 
         tableEntries.push({tag: tag, offset: offset, compression: compression,
-            compressedLength: compLength, originalLength: origLength});
+            compressedLength: compLength, length: origLength});
         p += 20;
     }
 
@@ -144,9 +144,9 @@ function parseWOFFTableEntries(data, numTables) {
 function uncompressTable(data, tableEntry) {
     if (tableEntry.compression === 'WOFF') {
         var inBuffer = new Uint8Array(data.buffer, tableEntry.offset + 2, tableEntry.compressedLength - 2);
-        var outBuffer = new Uint8Array(tableEntry.originalLength);
+        var outBuffer = new Uint8Array(tableEntry.length);
         inflate(inBuffer, outBuffer);
-        if (outBuffer.byteLength !== tableEntry.originalLength) {
+        if (outBuffer.byteLength !== tableEntry.length) {
             throw new Error('Decompression error: ' + tableEntry.tag + ' decompressed length doesn\'t match recorded length');
         }
 


### PR DESCRIPTION
https://github.com/nodebox/opentype.js/issues/275

## Description
An error was being thrown in parseBuffer(...) when calling parseShortList(...) due to a discrepancy in how parseOpenTypeTableEntries(...) & parseWOFFTableEntries(...) returns values. This ended up throwing an error when parsing any WOFF font that includes a cvt table.

## Motivation and Context
parseShortList(tableEntry.length / 2) was expecting tableEntry to have a length, but the WOFF parser only returns the values compressedLength and originalLength so tableEntry.length ends up equalling undefined. This ends up throwing an error when new Array(count) is being called in parseShortList(...)

## How Has This Been Tested?
I ran through `npm test run`. I tested again previously failing fonts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
