### PR TITLE
Fix Font.getPaths to pass along options and this

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -326,7 +326,7 @@ Font.prototype.getPath = function(text, x, y, fontSize, options) {
 Font.prototype.getPaths = function(text, x, y, fontSize, options) {
     const glyphPaths = [];
     this.forEachGlyph(text, x, y, fontSize, options, function(glyph, gX, gY, gFontSize) {
-        const glyphPath = glyph.getPath(gX, gY, gFontSize);
+        const glyphPath = glyph.getPath(gX, gY, gFontSize, options, this);
         glyphPaths.push(glyphPath);
     });
 


### PR DESCRIPTION
`Font.getPath` was passing along `options` and `this` but `Font.getPaths` is hitting the same endpoint without those arguments.
## Description
I added the `options` object and `this` onto the arguments for `glyph.getPath`

## Motivation and Context
This fixes using options on `Font.getPaths` so that it works the same as `Font.getPath`. The specific issue I was having was that hinting wasn't being applied.

## How Has This Been Tested?
I ran it and it worked. I didn't test too vigorously because it seems like it was just an overlooked change when hinting was added. If there's a good way to unit test this I'm open to suggestions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
