### PR TITLE
Enable uglify's mangle and compress optimizations for a ~30% smaller …

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch": "rollup -c -w",
     "test": "mocha --require reify --compilers js:buble/register --recursive && jshint . && jscs .",
     "build": "rollup -c",
-    "minify": "uglifyjs ./dist/opentype.js > ./dist/opentype.min.js",
+    "minify": "uglifyjs  --compress --mangle -- ./dist/opentype.js > ./dist/opentype.min.js",
     "dist": "npm run test && npm run build && npm run minify"
   },
   "devDependencies": {
@@ -45,8 +45,7 @@
     "rollup-plugin-license": "^0.4.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-watch": "^3.2.2",
-    "uglify-js": "^3.0.14",
-    "uglifyjs": "^2.4.11"
+    "uglify-js": "^3.0.14"
   },
   "browser": {
     "fs": false

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rollup-plugin-license": "^0.4.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-watch": "^3.2.2",
-    "uglify-js": "^3.0.14"
+    "uglify-js": "^3.3.10"
   },
   "browser": {
     "fs": false


### PR DESCRIPTION
## Description

The existing uglify minification did not enable its 'mangle' or 'compress' optimizations. Doing so results in a ~30% smaller opentype.min.js, mostly by shortening local variable names, and is theoretically a safe transformation.

Size before: 202780 bytes
Size after: 143972 bytes

I also removed the extra older `uglifyjs` dependency from package.json, as it did not appear to be used.

## How Has This Been Tested?

The existing mocha test for the minified file still passes. I also tested the index.html example with the newly minified file and verified it works as before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (improvement, really) (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
