### PR TITLE
Better parsing of NULL pointers (#254)

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -519,7 +519,7 @@ Parser.prototype.parseScriptList = function() {
                 langSys: Parser.pointer(langSysTable)
             })
         })
-    }));
+    })) || [];
 };
 
 Parser.prototype.parseFeatureList = function() {
@@ -529,7 +529,7 @@ Parser.prototype.parseFeatureList = function() {
             featureParams: Parser.offset16,
             lookupListIndexes: Parser.uShortList
         })
-    }));
+    })) || [];
 };
 
 Parser.prototype.parseLookupList = function(lookupTableParsers) {
@@ -544,7 +544,7 @@ Parser.prototype.parseLookupList = function(lookupTableParsers) {
             subtables: this.parseList(Parser.pointer(lookupTableParsers[lookupType])),
             markFilteringSet: useMarkFilteringSet ? this.parseUShort() : undefined
         };
-    })));
+    }))) || [];
 };
 
 Parser.prototype.parseFeatureVariationsList = function() {
@@ -557,7 +557,7 @@ Parser.prototype.parseFeatureVariationsList = function() {
             featureTableSubstitutionOffset: Parser.offset32
         });
         return featureVariations;
-    });
+    }) || [];
 };
 
 export default {

--- a/test/tables/gsub.js
+++ b/test/tables/gsub.js
@@ -38,6 +38,13 @@ describe('tables/gsub.js', function() {
         assert.deepEqual(gsub.parse(data), { version: 1, scripts: [], features: [], lookups: [] });
     });
 
+    it('can parse a GSUB header with null pointers', function() {
+        const data = unhex(
+            '00010000 0000 0000 0000'
+        );
+        assert.deepEqual(gsub.parse(data), { version: 1, scripts: [], features: [], lookups: [] });
+    });
+
     //// Lookup type 1 ////////////////////////////////////////////////////////
     it('can parse lookup1 substFormat 1', function() {
         // https://www.microsoft.com/typography/OTSPEC/GSUB.htm#EX2


### PR DESCRIPTION
A lot of fonts have been seen with GSUB tables containing only NULL pointers.

## Description
Null pointers in GSUB sublists are now converted to empty lists instead of undefined.

## Motivation and Context
Fixes #254 

## How Has This Been Tested?
Tested against all fonts reported in #254 (LeagueGothic, Gabriela, Cutive Mono).
Added a unit test.

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly
- [x] I have read the **CONTRIBUTING** document.
