### PR TITLE
Fix bad path init

### DIFF
--- a/src/glyph.js
+++ b/src/glyph.js
@@ -6,7 +6,7 @@ import Path from './path';
 import glyf from './tables/glyf';
 
 function getPathDefinition(glyph, path) {
-    let _path = path || {commands: []};
+    let _path = path || new Path();
     return {
         configurable: true,
 


### PR DESCRIPTION
In some cases (e.g. whitespace glyphs on Gabriela) this could lead to a
"glyph.path.toPathData is not a function" error, because glyph.path was not an instance of Path.

Gabriela:
https://fonts.gstatic.com/s/gabriela/v6/qkBWXvsO6sreR8E-b8m5xL0.woff

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
