### PR TITLE
Fix rendering test

### DIFF
--- a/bin/test-render
+++ b/bin/test-render
@@ -24,7 +24,7 @@
 //
 // When viewing the SVG, it will be upside-down (since glyphs are designed Y-up).
 
-var opentype = require('../src/opentype.js');
+var opentype = require('../dist/opentype.js');
 
 const SVG_FOOTER = `</svg>`;
 


### PR DESCRIPTION
## Description
Rendering tests at https://github.com/unicode-org/text-rendering-tests fail, probably because Node doesn't like the "import" statement in the src/ files ("SyntaxError: Unexpected token import")

Redirecting the require to the compiled file in dist/ solves it.

## How Has This Been Tested?
Command-line `node ./bin/test-render --font=fonts/FiraSansOT-Medium.otf --testcase=TEST-1 --render=BALL`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **CONTRIBUTING** document.
