### PR TITLE
Support UTF-16 surrogate pairs

### DIFF
--- a/bin/test-render
+++ b/bin/test-render
@@ -61,9 +61,9 @@ function renderSVG() {
 
     var glyphSet = new Set();
     let x = 0;
-    for (let i = 0; i < textToRender.length; i++) {
-        const c = textToRender[i];
-        const glyph = font.charToGlyph(c);
+    const glyphs = font.stringToGlyphs(textToRender);
+    for (let i = 0; i < glyphs.length; i++) {
+        const glyph = glyphs[i];
         const symbolId = testcase + '.' + glyph.name;
         if (!glyphSet.has(glyph)) {
             glyphSet.add(glyph);

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -1,3 +1,5 @@
+import { getFirstCodePoint } from './util';
+
 // Glyph encoding
 
 const cffStandardStrings = [
@@ -133,7 +135,7 @@ function DefaultEncoding(font) {
 }
 
 DefaultEncoding.prototype.charToGlyphIndex = function(c) {
-    const code = c.charCodeAt(0);
+    const code = getFirstCodePoint(c);
     const glyphs = this.font.glyphs;
     if (glyphs) {
         for (let i = 0; i < glyphs.length; i += 1) {
@@ -163,7 +165,7 @@ function CmapEncoding(cmap) {
  * @return {number} The glyph index.
  */
 CmapEncoding.prototype.charToGlyphIndex = function(c) {
-    return this.cmap.glyphIndexMap[c.charCodeAt(0)] || 0;
+    return this.cmap.glyphIndexMap[getFirstCodePoint(c)] || 0;
 };
 
 /**
@@ -183,7 +185,7 @@ function CffEncoding(encoding, charset) {
  * @return {number} The index.
  */
 CffEncoding.prototype.charToGlyphIndex = function(s) {
-    const code = s.charCodeAt(0);
+    const code = getFirstCodePoint(s);
     const charName = this.encoding[code];
     return this.charset.indexOf(charName);
 };

--- a/src/font.js
+++ b/src/font.js
@@ -6,7 +6,7 @@ import { DefaultEncoding } from './encoding';
 import glyphset from './glyphset';
 import Position from './position';
 import Substitution from './substitution';
-import { isBrowser, checkArgument, arrayBufferToNodeBuffer } from './util';
+import { isBrowser, checkArgument, arrayBufferToNodeBuffer, isHighSurrogate, isLowSurrogate } from './util';
 import HintingTrueType from './hintingtt';
 
 /**
@@ -154,8 +154,14 @@ Font.prototype.stringToGlyphs = function(s, options) {
     // Get glyph indexes
     const indexes = [];
     for (let i = 0; i < s.length; i += 1) {
-        const c = s[i];
-        indexes.push(this.charToGlyphIndex(c));
+        if ((i !== s.length - 1) && isHighSurrogate(s.charCodeAt(i)) && isLowSurrogate(s.charCodeAt(i + 1))) {
+            // Surrogate pair
+            indexes.push(this.charToGlyphIndex(s.substr(i, 2)));
+            i += 1;
+        } else {
+            const c = s[i];
+            indexes.push(this.charToGlyphIndex(c));
+        }
     }
     let length = indexes.length;
 

--- a/src/util.js
+++ b/src/util.js
@@ -32,4 +32,28 @@ function checkArgument(expression, message) {
     }
 }
 
-export { isBrowser, isNode, nodeBufferToArrayBuffer, arrayBufferToNodeBuffer, checkArgument };
+function isHighSurrogate(code) {
+    return code >= 0xD800 && code <= 0xDBFF;
+}
+
+function isLowSurrogate(code) {
+    return code >= 0xDC00 && code <= 0xDFFF;
+}
+
+function getFirstCodePoint(s) {
+    if (s.length > 1 && isHighSurrogate(s.charCodeAt(0)) && isLowSurrogate(s.charCodeAt(1))) {
+        return 0x10000 + ((s.charCodeAt(0) & 0x03FF) << 10) + (s.charCodeAt(1) & 0x03FF);
+    }
+    return s.charCodeAt(0);
+}
+
+export {
+    isBrowser,
+    isNode,
+    nodeBufferToArrayBuffer,
+    arrayBufferToNodeBuffer,
+    checkArgument,
+    isHighSurrogate,
+    isLowSurrogate,
+    getFirstCodePoint
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the code of getting the code point of a character in `stringToGlyphs` and `charToGlyph` for supporting surrogate pairs. JavaScript strings are encoded in UCS-2 and using the concept of surrogate pairs in UTF-16 for `U+10000` to `U+10FFFF`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It addresses #168 and #327, and the issue mentioned by @schuylr in #297.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. `npm run test`
2. `npm run dist` and `npm run start` to check the usages of `opentype.js` via `http://localhost:8080`
3. Run the rendering test from https://github.com/unicode-org/text-rendering-tests. After the fix, it passed `CFF-1` and `CFF-2` test cases. Results in `GVAR-4`, `GVAR-5` and `GVAR-6`

 are still incorrect, but the icon is shown instead of 2 dots. See the screenshots below.

## Screenshots (if appropriate):
![CFF-1 and CFF-2](https://user-images.githubusercontent.com/4450446/37351693-96dcd44a-2716-11e8-8996-4996865c1afe.png)
![GVAR-4, GVAR-5 and GVAR-6](https://user-images.githubusercontent.com/4450446/37351857-f4c99b88-2716-11e8-8077-21ea7d869d88.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
