### PR TITLE
Restore simple GPOS kerning in font.getKerningValue

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -229,6 +229,8 @@ Font.prototype.glyphIndexToName = function(gid) {
  * and the right glyph (or its index). If no kerning pair is found, return 0.
  * The kerning value gets added to the advance width when calculating the spacing
  * between glyphs.
+ * For GPOS kerning, this method uses the default script and language, which covers
+ * most use cases. To have greater control, use font.position.getKerningValue .
  * @param  {opentype.Glyph} leftGlyph
  * @param  {opentype.Glyph} rightGlyph
  * @return {Number}
@@ -236,6 +238,11 @@ Font.prototype.glyphIndexToName = function(gid) {
 Font.prototype.getKerningValue = function(leftGlyph, rightGlyph) {
     leftGlyph = leftGlyph.index || leftGlyph;
     rightGlyph = rightGlyph.index || rightGlyph;
+    const gposKerning = this.position.defaultKerningTables;
+    if (gposKerning) {
+        return this.position.getKerningValue(gposKerning, leftGlyph, rightGlyph);
+    }
+    // "kern" table
     return this.kerningPairs[leftGlyph + ',' + rightGlyph] || 0;
 };
 

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -335,6 +335,7 @@ function parseBuffer(buffer) {
     if (gposTableEntry) {
         const gposTable = uncompressTable(data, gposTableEntry);
         font.tables.gpos = gpos.parse(gposTable.data, gposTable.offset);
+        font.position.init();
     }
 
     if (gsubTableEntry) {

--- a/src/position.js
+++ b/src/position.js
@@ -17,6 +17,14 @@ function Position(font) {
 Position.prototype = Layout.prototype;
 
 /**
+ * Init some data for faster and easier access later.
+ */
+Position.prototype.init = function() {
+    const script = this.getDefaultScriptName();
+    this.defaultKerningTables = this.getKerningTables(script);
+};
+
+/**
  * Find a glyph pair in a list of lookup tables of type 2 and retrieve the xAdvance kerning value.
  *
  * @param {integer} leftIndex - left glyph index


### PR DESCRIPTION
Fix #332 (API break introduced by #323)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
