### PR TITLE
Support non-Basic-Multilingual-Plane (BMP) characters

### DIFF
--- a/bin/test-render
+++ b/bin/test-render
@@ -61,9 +61,9 @@ function renderSVG() {
 
     var glyphSet = new Set();
     let x = 0;
-    for (let i = 0; i < textToRender.length; i++) {
-        const c = textToRender[i];
-        const glyph = font.charToGlyph(c);
+    const glyphs = font.stringToGlyphs(textToRender);
+    for (let i = 0; i < glyphs.length; i++) {
+        const glyph = glyphs[i];
         const symbolId = testcase + '.' + glyph.name;
         if (!glyphSet.has(glyph)) {
             glyphSet.add(glyph);

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "fs": false
   },
   "dependencies": {
+    "string.prototype.codepointat": "^0.2.0",
     "tiny-inflate": "^1.0.2"
   }
 }

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -133,7 +133,7 @@ function DefaultEncoding(font) {
 }
 
 DefaultEncoding.prototype.charToGlyphIndex = function(c) {
-    const code = c.charCodeAt(0);
+    const code = c.codePointAt(0);
     const glyphs = this.font.glyphs;
     if (glyphs) {
         for (let i = 0; i < glyphs.length; i += 1) {
@@ -163,7 +163,7 @@ function CmapEncoding(cmap) {
  * @return {number} The glyph index.
  */
 CmapEncoding.prototype.charToGlyphIndex = function(c) {
-    return this.cmap.glyphIndexMap[c.charCodeAt(0)] || 0;
+    return this.cmap.glyphIndexMap[c.codePointAt(0)] || 0;
 };
 
 /**
@@ -183,7 +183,7 @@ function CffEncoding(encoding, charset) {
  * @return {number} The index.
  */
 CffEncoding.prototype.charToGlyphIndex = function(s) {
-    const code = s.charCodeAt(0);
+    const code = s.codePointAt(0);
     const charName = this.encoding[code];
     return this.charset.indexOf(charName);
 };

--- a/src/font.js
+++ b/src/font.js
@@ -9,6 +9,9 @@ import Substitution from './substitution';
 import { isBrowser, checkArgument, arrayBufferToNodeBuffer } from './util';
 import HintingTrueType from './hintingtt';
 
+// This code is based on Array.from implementation for strings in https://github.com/mathiasbynens/Array.from
+const arrayFromString = Array.from || (s => s.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]?|[^\uD800-\uDFFF]|./g) || []);
+
 /**
  * @typedef FontOptions
  * @type Object
@@ -151,10 +154,6 @@ Font.prototype.charToGlyph = function(c) {
  */
 Font.prototype.stringToGlyphs = function(s, options) {
     options = options || this.defaultRenderOptions;
-
-    // This code is based on Array.from implementation for strings in https://github.com/mathiasbynens/Array.from
-    const arrayFromString = Array.from || (s => s.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]?|[^\uD800-\uDFFF]|./g) || []);
-
     // Get glyph indexes
     const chars = arrayFromString(s);
     const indexes = [];

--- a/src/font.js
+++ b/src/font.js
@@ -154,8 +154,15 @@ Font.prototype.stringToGlyphs = function(s, options) {
     // Get glyph indexes
     const indexes = [];
     for (let i = 0; i < s.length; i += 1) {
-        const c = s[i];
-        indexes.push(this.charToGlyphIndex(c));
+        const code = s.codePointAt(i);
+        if (code > 65535) {
+            // Surrogate pairs
+            indexes.push(this.charToGlyphIndex(s.substr(i, 2)));
+            i += 1;
+        } else {
+            const c = s[i];
+            indexes.push(this.charToGlyphIndex(c));
+        }
     }
     let length = indexes.length;
 

--- a/src/font.js
+++ b/src/font.js
@@ -151,18 +151,16 @@ Font.prototype.charToGlyph = function(c) {
  */
 Font.prototype.stringToGlyphs = function(s, options) {
     options = options || this.defaultRenderOptions;
+
+    // This code is based on Array.from implementation for strings in https://github.com/mathiasbynens/Array.from
+    const arrayFromString = Array.from || (s => s.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]?|[^\uD800-\uDFFF]|./g) || []);
+
     // Get glyph indexes
+    const chars = arrayFromString(s);
     const indexes = [];
-    for (let i = 0; i < s.length; i += 1) {
-        const code = s.codePointAt(i);
-        if (code > 65535) {
-            // Surrogate pairs
-            indexes.push(this.charToGlyphIndex(s.substr(i, 2)));
-            i += 1;
-        } else {
-            const c = s[i];
-            indexes.push(this.charToGlyphIndex(c));
-        }
+    for (let i = 0; i < chars.length; i += 1) {
+        const c = chars[i];
+        indexes.push(this.charToGlyphIndex(c));
     }
     let length = indexes.length;
 

--- a/src/opentype.js
+++ b/src/opentype.js
@@ -5,6 +5,7 @@
 
 /* global DataView, Uint8Array, XMLHttpRequest  */
 
+import 'string.prototype.codepointat';
 import inflate from 'tiny-inflate';
 import Font from './font';
 import Glyph from './glyph';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A new pull request after changing the code per the comments in #331.

Replaced `charCodeAt()` to `codePointAt()`  in `encoding.js` and modified `font.js` to handle surrogate pairs, for supporting non-Basic-Multilingual-Plane characters (i.e. `U+10000` to `U+10FFFF`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It addresses #168 and #327, and the issue mentioned by @schuylr in #297.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. `npm run test`
2. `npm run dist` and `npm run start` to check the usages of `opentype.js` via `http://localhost:8080`
3. Run the rendering test from https://github.com/unicode-org/text-rendering-tests. After the fix, it passed `CFF-1` and `CFF-2` test cases. Results in `GVAR-4`, `GVAR-5` and `GVAR-6`
4. Tested in Internet Explorer 11 for the polyfill of `String.prototype.codePointAt`

 are still incorrect, but the icon is shown instead of 2 dots. See the screenshots below.

## Screenshots (if appropriate):
![CFF-1 and CFF-2](https://user-images.githubusercontent.com/4450446/37351693-96dcd44a-2716-11e8-8996-4996865c1afe.png)
![GVAR-4, GVAR-5 and GVAR-6](https://user-images.githubusercontent.com/4450446/37351857-f4c99b88-2716-11e8-8077-21ea7d869d88.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
