### PR TITLE
Prevent auto-generated postScriptName from containing whitespace

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -65,7 +65,8 @@ function Font(options) {
             fontFamily: {en: options.familyName || ' '},
             fontSubfamily: {en: options.styleName || ' '},
             fullName: {en: options.fullName || options.familyName + ' ' + options.styleName},
-            postScriptName: {en: options.postScriptName || options.familyName + options.styleName},
+            // postScriptName may not contain any whitespace
+            postScriptName: {en: options.postScriptName || (options.familyName + options.styleName).replace(/\s/g, '')},
             designer: {en: options.designer || ' '},
             designerURL: {en: options.designerURL || ' '},
             manufacturer: {en: options.manufacturer || ' '},


### PR DESCRIPTION
Whitespace characters are illegal in postScriptName and will result in
the font file being flagged as corrupt/invalid (at least on Windows 10).
Since all other fields are copied as-is from the options initialization
parameter without additional validation, I'm only stripping whitespace
in the case that opentype.js generates the postScriptName field
automagically from two other fields that _don't_ have the same
no-whitespace restriction.