### PR TITLE
Parse cmap table with platform 0 as well

### DIFF
--- a/src/tables/cmap.js
+++ b/src/tables/cmap.js
@@ -87,13 +87,14 @@ function parseCmapTable(data, start) {
     check.argument(cmap.version === 0, 'cmap table version should be 0.');
 
     // The cmap table can contain many sub-tables, each with their own format.
-    // We're only interested in a "platform 3" table. This is a Windows format.
+    // We're only interested in a "platform 0" (Unicode format) and "platform 3" (Windows format) table.
     cmap.numTables = parse.getUShort(data, start + 2);
     let offset = -1;
     for (let i = cmap.numTables - 1; i >= 0; i -= 1) {
         const platformId = parse.getUShort(data, start + 4 + (i * 8));
         const encodingId = parse.getUShort(data, start + 4 + (i * 8) + 2);
-        if (platformId === 3 && (encodingId === 0 || encodingId === 1 || encodingId === 10)) {
+        if ((platformId === 3 && (encodingId === 0 || encodingId === 1 || encodingId === 10)) ||
+            (platformId === 0 && (encodingId === 0 || encodingId === 1 || encodingId === 2 || encodingId === 3 || encodingId === 4))) {
             offset = parse.getULong(data, start + 4 + (i * 8) + 4);
             break;
         }


### PR DESCRIPTION
## Description
Adds support for cmap platformId, encodingId:
* [0, 0] Unicode, Default semantics
* [0, 1] Unicode, Version 1.1 semantics
* [0, 2] Unicode, ISO 10646 1993 semantics (deprecated)
* [0, 3] Unicode, Unicode 2.0 or later semantics (BMP only)
* [0, 4] Unicode, Unicode 2.0 or later semantics (non-BMP characters allowed)

## Motivation and Context
Issue #348

## How Has This Been Tested?
`npm test` and `npm start` (dropping a couple of fonts including that from #348)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
