### PR TITLE
font.download() uses window.URL instead of window.requestFileSystem

### DIFF
--- a/src/font.js
+++ b/src/font.js
@@ -502,24 +502,22 @@ Font.prototype.download = function(fileName) {
     const arrayBuffer = this.toArrayBuffer();
 
     if (isBrowser()) {
-        window.requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
-        window.requestFileSystem(window.TEMPORARY, arrayBuffer.byteLength, function(fs) {
-            fs.root.getFile(fileName, {create: true}, function(fileEntry) {
-                fileEntry.createWriter(function(writer) {
-                    const dataView = new DataView(arrayBuffer);
-                    const blob = new Blob([dataView], {type: 'font/opentype'});
-                    writer.write(blob);
+        window.URL = window.URL || window.webkitURL;
 
-                    writer.addEventListener('writeend', function() {
-                        // Navigating to the file will download it.
-                        location.href = fileEntry.toURL();
-                    }, false);
-                });
-            });
-        },
-        function(err) {
-            throw new Error(err.name + ': ' + err.message);
-        });
+        if (window.URL) {
+            const dataView = new DataView(arrayBuffer);
+            const blob = new Blob([dataView], {type: 'font/opentype'});
+
+            let link = document.createElement('a');
+            link.href = window.URL.createObjectURL(blob);
+            link.download = fileName;
+
+            let event = document.createEvent('MouseEvents');
+            event.initEvent('click', true, false);
+            link.dispatchEvent(event);
+        } else {
+            console.warn('Font file could not be downloaded. Try using a different browser.');
+        }
     } else {
         const fs = require('fs');
         const buffer = arrayBufferToNodeBuffer(arrayBuffer);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently `Font.download` utilizes `window.requestFileSystem` to save a file.  This method only works on Chrome (13+) and Opera (15+).  It's also non-standard.

Over at Glyphr Studio, we implement a method that uses `window.URL`, which works on a larger set of browsers : Chrome (32+), Opera (19+), Firefox (26+), Safari (7.1+), and all of Edge.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the past I've been taking the opentype.js dist file and modifying it to use this method before I include it in Glyphr Studio - which is silly 😄 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Loaded a font into the development server and tried `font.download();` on FireFox, Chrome, Opera, and Edge on Windows 10.  Used Browser Stack to test Safari on Mac.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
